### PR TITLE
Add Roofline support for Ubuntu 20.04

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -33,6 +33,7 @@ SOC_LIST = ["mi50", "mi100", "mi200"]
 DISTRO_MAP = {
     "platform:el8": "rhel8",
     "15.3": "sle15sp3",
+    "20.04": "ubuntu20_04"
 }
 version = os.path.join(OMNIPERF_HOME.parent, "VERSION")
 try:

--- a/src/common.py
+++ b/src/common.py
@@ -30,11 +30,7 @@ OMNIPERF_HOME = Path(__file__).resolve().parent
 # OMNIPERF INFO
 PROG = "omniperf"
 SOC_LIST = ["mi50", "mi100", "mi200"]
-DISTRO_MAP = {
-    "platform:el8": "rhel8",
-    "15.3": "sle15sp3",
-    "20.04": "ubuntu20_04"
-}
+DISTRO_MAP = {"platform:el8": "rhel8", "15.3": "sle15sp3", "20.04": "ubuntu20_04"}
 version = os.path.join(OMNIPERF_HOME.parent, "VERSION")
 try:
     with open(version, "r") as file:

--- a/src/omniperf
+++ b/src/omniperf
@@ -203,6 +203,7 @@ def detect_roofline():
     rocm_ver = mspec.rocmversion[:1]
 
     os_release = path("/etc/os-release").read_text()
+    ubuntu_distro = specs.search(r'VERSION_ID="(.*?)"', os_release)
     rhel_distro = specs.search(r'PLATFORM_ID="(.*?)"', os_release)
     sles_distro = specs.search(r'VERSION_ID="(.*?)"', os_release)
 
@@ -221,6 +222,9 @@ def detect_roofline():
     elif sles_distro == "15.3":
         # Must be a valid SLES machine
         distro = sles_distro
+    elif ubuntu_distro == "20.04":
+        # Must be a valid Ubuntu machine
+        distro = ubuntu_distro
     else:
         print("ROOFLINE ERROR: Cannot find a valid binary for your operating system")
         sys.exit(1)


### PR DESCRIPTION
Made some changes to code so we can support Ubuntu 20.04 in roofline:

- Added a compatible roofline from MIBench workflow
- Modified `detect_roofline()` to account for this new distro