### PR TITLE
Ubuntu roofline binary isn't installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,7 @@ install(
 # src/utils/rooflines
 install(PROGRAMS src/utils/rooflines/roofline-rhel8-mi200-rocm5
                  src/utils/rooflines/roofline-sle15sp3-mi200-rocm5
+                 src/utils/rooflines/roofline-ubuntu20_04-mi200-rocm5
         DESTINATION ${CMAKE_INSTALL_BINDIR}/utils/rooflines)
 # src/perfmon_pub
 install(


### PR DESCRIPTION
Add code to include Ubuntu 20.04 roofline binary in packaging. 

- Modified CMakeLists