### PR TITLE
Allow to specify the maximum number of kernels shown

### DIFF
--- a/src/omniperf_analyze/omniperf_analyze.py
+++ b/src/omniperf_analyze/omniperf_analyze.py
@@ -138,13 +138,12 @@ def run_gui(args, runs):
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.CYBORG])
 
     if len(runs) == 1:
-        num_results = 10
         file_io.create_df_kernel_top_stats(
             args.path[0][0],
             runs[args.path[0][0]].filter_gpu_ids,
             runs[args.path[0][0]].filter_dispatch_ids,
             args.time_unit,
-            num_results,
+            args.max_kernel_num,
         )
         runs[args.path[0][0]].raw_pmc = file_io.create_df_pmc(
             args.path[0][0], args.verbose
@@ -187,13 +186,12 @@ def run_cli(args, runs):
     # which archConfig passed into show_all function.
     # After decide to how to manage kernels display patterns, we can revisit it.
     for d in args.path:
-        num_results = 10
         file_io.create_df_kernel_top_stats(
             d[0],
             runs[d[0]].filter_gpu_ids,
             runs[d[0]].filter_dispatch_ids,
             args.time_unit,
-            num_results,
+            args.max_kernel_num,
         )
         runs[d[0]].raw_pmc = file_io.create_df_pmc(
             d[0], args.verbose

--- a/src/omniperf_analyze/omniperf_analyze.py
+++ b/src/omniperf_analyze/omniperf_analyze.py
@@ -155,6 +155,7 @@ def run_gui(args, runs):
             "gpu": runs[args.path[0][0]].filter_gpu_ids,
             "dispatch": runs[args.path[0][0]].filter_dispatch_ids,
             "normalization": args.normal_unit,
+            "top_n": args.max_kernel_num,
         }
 
         gui.build_layout(

--- a/src/omniperf_analyze/utils/file_io.py
+++ b/src/omniperf_analyze/utils/file_io.py
@@ -111,7 +111,7 @@ def create_df_kernel_top_stats(
     filter_gpu_ids,
     filter_dispatch_ids,
     time_unit,
-    num_results,
+    max_kernel_num,
     sortby="sum",
 ):
     """
@@ -172,13 +172,13 @@ def create_df_kernel_top_stats(
     if sortby == "sum":
         grouped = grouped.sort_values(by=("Sum" + time_unit_str), ascending=False)
 
-        grouped = grouped.head(num_results)  # Display only the top n results
+        grouped = grouped.head(max_kernel_num)  # Display only the top n results
 
         grouped.to_csv(os.path.join(raw_data_dir, "pmc_kernel_top.csv"), index=False)
     elif sortby == "kernel":
         grouped = grouped.sort_values("KernelName")
 
-        grouped = grouped.head(num_results)  # Display only the top n results
+        grouped = grouped.head(max_kernel_num)  # Display only the top n results
         grouped.to_csv(os.path.join(raw_data_dir, "pmc_kernel_top.csv"), index=False)
 
 

--- a/src/omniperf_analyze/utils/gui.py
+++ b/src/omniperf_analyze/utils/gui.py
@@ -423,10 +423,11 @@ def build_layout(
         [Input("kernel-filt", "value")],
         [Input("gcd-filt", "value")],
         [Input("norm-filt", "value")],
+        [Input("top-n-filt", "value")],
         [State("container", "children")],
     )
     def generate_from_filter(
-        disp_filt, kernel_filter, gcd_filter, norm_filt, div_children
+        disp_filt, kernel_filter, gcd_filter, norm_filt, top_n_filt, div_children
     ):
         if verbose >= 1:
             print("normalization is ", norm_filt)
@@ -438,18 +439,19 @@ def build_layout(
         if verbose >= 1:
             print("disp-filter is ", disp_filt)
             print("kernel-filter is ", kernel_filter)
-            print("gpu-filter is ", gcd_filter, "\n")
+            print("gpu-filter is ", gcd_filter)
+            print("top-n kernel filter is ", top_n_filter, "\n")
         base_data[base_run].filter_kernel_ids = kernel_filter
         base_data[base_run].filter_gpu_ids = gcd_filter
         base_data[base_run].filter_dispatch_ids = disp_filt
+        base_data[base_run].filter_top_n = top_n_filt
         # Reload the pmc_kernel_top.csv for Top Stats panel
-        num_results = 10
         file_io.create_df_kernel_top_stats(
             path_to_dir,
             base_data[base_run].filter_gpu_ids,
             base_data[base_run].filter_dispatch_ids,
             time_unit,
-            num_results,
+            base_data[base_run].filter_top_n,
         )
         is_gui = True
         # Only display basic metrics if no filters are applied

--- a/src/omniperf_analyze/utils/gui_components/header.py
+++ b/src/omniperf_analyze/utils/gui_components/header.py
@@ -241,6 +241,28 @@ def get_header(raw_pmc, input_filters, kernel_names):
                                         children=[
                                             html.A(
                                                 className="smoothscroll",
+                                                children=["Top N:"],
+                                            ),
+                                            dcc.Dropdown(
+                                                [1, 5, 10, 15, 20, 50, 100],
+                                                id="top-n-filt",
+                                                value=input_filters[
+                                                    "top_n"
+                                                ],  # default to any dispatch filters passed as args
+                                                clearable=False,
+                                                style={"width": "50px"},
+                                            ),
+                                        ]
+                                    )
+                                ],
+                            ),
+                            html.Li(
+                                className="filter",
+                                children=[
+                                    html.Div(
+                                        children=[
+                                            html.A(
+                                                className="smoothscroll",
                                                 children=["Kernels:"],
                                             ),
                                             dcc.Dropdown(

--- a/src/parser.py
+++ b/src/parser.py
@@ -451,7 +451,7 @@ def parse(my_parser):
         metavar="",
         type=int,
         default=10,
-        help="\t\tSpecify the maximum number of kernels shown",
+        help="\t\tSpecify the maximum number of kernels shown (DEFAULT: 10)",
     )
     analyze_group.add_argument(
         "--config-dir",

--- a/src/parser.py
+++ b/src/parser.py
@@ -446,6 +446,14 @@ def parse(my_parser):
         help="\t\tSpecify the normalization unit: (DEFAULT: per_wave)\n\t\t   per_wave\n\t\t   per_cycle\n\t\t   per_second\n\t\t   per_kernel",
     )
     analyze_group.add_argument(
+        "--max-kernel-num",
+        dest="max_kernel_num",
+        metavar="",
+        type=int,
+        default=10,
+        help="\t\tSpecify the maximum number of kernels shown",
+    )
+    analyze_group.add_argument(
         "--config-dir",
         dest="config_dir",
         metavar="",


### PR DESCRIPTION
Allow end users to specify the maximum number of kernels shown in Top Stats