### PR TITLE
refactoring saved df files

### DIFF
--- a/src/omniperf_analyze/omniperf_analyze.py
+++ b/src/omniperf_analyze/omniperf_analyze.py
@@ -209,6 +209,7 @@ def run_cli(args, runs):
             runs,
             archConfigs["gfx90a"],
             output,
+            args.df_file_dir,
             args.decimal,
             args.time_unit,
             args.cols,

--- a/src/omniperf_analyze/utils/parser.py
+++ b/src/omniperf_analyze/utils/parser.py
@@ -718,22 +718,6 @@ def load_table_data(workload, dir, is_gui, debug, verbose):
         debug,
     )
 
-    # Save workload
-    name = "saved_analysis"
-    out_path = os.path.join(dir, name)
-    try:
-        os.mkdir(out_path)
-        if verbose >= 1:
-            print("Created a Saved Analysis folder")
-    except OSError as error:
-        if verbose >= 1:
-            print("Saved Analysis folder exists")
-    for id, df in workload.dfs.items():
-        if "coll_level" in list(df.columns):
-            df = df.drop(["coll_level", "Tips"], axis=1)
-        df.to_csv(os.path.join(out_path, str(id) + ".csv"), index=False)
-
-
 def build_comparable_columns(time_unit):
     """
     Build comparable columns/headers for display

--- a/src/omniperf_analyze/utils/parser.py
+++ b/src/omniperf_analyze/utils/parser.py
@@ -718,6 +718,7 @@ def load_table_data(workload, dir, is_gui, debug, verbose):
         debug,
     )
 
+
 def build_comparable_columns(time_unit):
     """
     Build comparable columns/headers for display

--- a/src/omniperf_analyze/utils/tty.py
+++ b/src/omniperf_analyze/utils/tty.py
@@ -23,6 +23,7 @@
 ##############################################################################el
 
 import pandas as pd
+from pathlib import Path
 from tabulate import tabulate
 
 from omniperf_analyze.utils import schema, parser
@@ -47,7 +48,8 @@ def string_multiple_lines(source, width, max_rows):
     return "\n".join(lines)
 
 
-def show_all(runs, archConfigs, output, decimal, time_unit, selected_cols, verbose):
+def show_all(runs, archConfigs, output, df_file_dir, decimal, time_unit,
+             selected_cols, verbose):
     """
     Show all panels with their data in plain text mode.
     """
@@ -152,15 +154,24 @@ def show_all(runs, archConfigs, output, decimal, time_unit, selected_cols, verbo
 
                 if not df.empty:
                     # subtitle for each table in a panel if existing
+                    table_id_str = str(table_config["id"] // 100) + "." + str(
+                        table_config["id"] % 100)
+
                     if "title" in table_config and table_config["title"]:
-                        ss += (
-                            str(table_config["id"] // 100)
-                            + "."
-                            + str(table_config["id"] % 100)
-                            + " "
-                            + table_config["title"]
-                            + "\n"
-                        )
+                        ss += (table_id_str + " " + table_config["title"] +
+                               "\n")
+
+                    if df_file_dir:
+                        p = Path(df_file_dir)
+                        if not p.exists():
+                            p.mkdir()
+                        if p.is_dir():
+                            if "title" in table_config and table_config[
+                                    "title"]:
+                                table_id_str += ("_" + table_config["title"])
+                            df.to_csv(p.joinpath(
+                                table_id_str.replace(" ", "_") + ".csv"),
+                                      index=False)
 
                     # NB:
                     # "columnwise: True" is a special attr of a table/df

--- a/src/omniperf_analyze/utils/tty.py
+++ b/src/omniperf_analyze/utils/tty.py
@@ -48,8 +48,9 @@ def string_multiple_lines(source, width, max_rows):
     return "\n".join(lines)
 
 
-def show_all(runs, archConfigs, output, df_file_dir, decimal, time_unit,
-             selected_cols, verbose):
+def show_all(
+    runs, archConfigs, output, df_file_dir, decimal, time_unit, selected_cols, verbose
+):
     """
     Show all panels with their data in plain text mode.
     """
@@ -154,24 +155,26 @@ def show_all(runs, archConfigs, output, df_file_dir, decimal, time_unit,
 
                 if not df.empty:
                     # subtitle for each table in a panel if existing
-                    table_id_str = str(table_config["id"] // 100) + "." + str(
-                        table_config["id"] % 100)
+                    table_id_str = (
+                        str(table_config["id"] // 100)
+                        + "."
+                        + str(table_config["id"] % 100)
+                    )
 
                     if "title" in table_config and table_config["title"]:
-                        ss += (table_id_str + " " + table_config["title"] +
-                               "\n")
+                        ss += table_id_str + " " + table_config["title"] + "\n"
 
                     if df_file_dir:
                         p = Path(df_file_dir)
                         if not p.exists():
                             p.mkdir()
                         if p.is_dir():
-                            if "title" in table_config and table_config[
-                                    "title"]:
-                                table_id_str += ("_" + table_config["title"])
-                            df.to_csv(p.joinpath(
-                                table_id_str.replace(" ", "_") + ".csv"),
-                                      index=False)
+                            if "title" in table_config and table_config["title"]:
+                                table_id_str += "_" + table_config["title"]
+                            df.to_csv(
+                                p.joinpath(table_id_str.replace(" ", "_") + ".csv"),
+                                index=False,
+                            )
 
                     # NB:
                     # "columnwise: True" is a special attr of a table/df

--- a/src/parser.py
+++ b/src/parser.py
@@ -469,6 +469,12 @@ def parse(my_parser):
         help="\t\tSpecify the decimal to display. (DEFAULT: 2)",
     )
     analyze_group.add_argument(
+        "--save-dfs",
+        dest="df_file_dir",
+        metavar="",
+        help="\t\tSpecify the dirctory to save analysis dataframe csv files.",
+    )
+    analyze_group.add_argument(
         "--cols",
         type=int,
         dest="cols",


### PR DESCRIPTION
Save analysis dataframes in that loading function with verbose actually is not a bad idea! 
However, there are some reasons to refactoring the code a bit:
* Writing to any dir without asking user is not a good practice(My current implementation to write TopStats there is a tmp solution, it is not good and need to be fixed in proper way ). 
* Implement it in tty will guarantee to save whatever user saw in cli. It is hard to imagine users want to save dfs in gui when loading(may be a bit confused when changing filter).
* It is easy to retrieve table title info in tty and put it into file name.   
 