### PR TITLE
Fix merge on grid

### DIFF
--- a/src/utils/perfagg.py
+++ b/src/utils/perfagg.py
@@ -122,7 +122,7 @@ def join_prof(workload_dir, join_type, log_file, verbose, out=None):
     duplicate_cols = {
         "gpu": [col for col in df.columns if "gpu" in col],
         "grd": [col for col in df.columns if "grd" in col],
-        "wpr": [col for col in df.columns if "wgr" in col],
+        "wgr": [col for col in df.columns if "wgr" in col],
         "lds": [col for col in df.columns if "lds" in col],
         "scr": [col for col in df.columns if "scr" in col],
         "arch_vgpr": [col for col in df.columns if "arch_vgpr" in col],

--- a/src/utils/perfagg.py
+++ b/src/utils/perfagg.py
@@ -107,7 +107,9 @@ def join_prof(workload_dir, join_type, log_file, verbose, out=None):
             _df["key"] = _df.KernelName + " - " + key.astype(str)
         elif join_type == "grid":
             key = _df.groupby(["KernelName", "grd"]).cumcount()
-            _df["key"] = _df.KernelName + " - " + _df.grd.astype(str) + " - " + key.astype(str)
+            _df["key"] = (
+                _df.KernelName + " - " + _df.grd.astype(str) + " - " + key.astype(str)
+            )
         else:
             print("ERROR: Unrecognized --join-type")
             sys.exit(1)

--- a/src/utils/perfagg.py
+++ b/src/utils/perfagg.py
@@ -104,13 +104,14 @@ def join_prof(workload_dir, join_type, log_file, verbose, out=None):
         _df = pd.read_csv(file)
         if join_type == "kernel":
             key = _df.groupby("KernelName").cumcount()
+            _df["key"] = _df.KernelName + " - " + key.astype(str)
         elif join_type == "grid":
             key = _df.groupby(["KernelName", "grd"]).cumcount()
+            _df["key"] = _df.KernelName + " - " + _df.grd.astype(str) + " - " + key.astype(str)
         else:
             print("ERROR: Unrecognized --join-type")
             sys.exit(1)
 
-        _df["key"] = _df.KernelName + " - " + key.astype(str)
         if df is None:
             df = _df
         else:


### PR DESCRIPTION
This fixes an issue reported by a user trying the new merge functionality on Pele.


The issue (essentially) was that when using the 'grid' join type, we were:

- creating the cumulative count (the 'key' series) by coind a cumcount() on `_df.groupby(["KernelName", "grd"])`: https://github.com/AMDResearch/omniperf/blob/c5a19ca06a879302ba183aa08033849ba448a407/src/utils/perfagg.py#L108
- However, when actually creating the key to join on (https://github.com/AMDResearch/omniperf/blob/c5a19ca06a879302ba183aa08033849ba448a407/src/utils/perfagg.py#L113) we were not including the "grd" as part of the key. 

The result was that we would have many duplicate keys, and on the merge the data-frame would ~ double in size.  Rinse and repeat a dozen times or so, and we would observe a OOM crash.

This fixes this issue by making the "key" entry we join on match the cumulative count we create.  We may want to think of more robust error detection here though.  Perhaps we could experiment with the "one_to_one" validation scheme in `pandas`?