### PR TITLE
Update MFMA peaks to reflect CDNA3

### DIFF
--- a/src/omniperf_analyze/configs/gfx90a/0200_system-speed-of-light.yaml
+++ b/src/omniperf_analyze/configs/gfx90a/0200_system-speed-of-light.yaml
@@ -44,16 +44,16 @@ Panel Config:
           MFMA FLOPs (BF16):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (EndNs - BeginNs)))
             unit: GFLOP
-            peak: ((($sclk * $numCU) * 4096) / 1000)
+            peak: ((($sclk * $numCU) * 512) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 4096) / 1000))
+              / ((($sclk * $numCU) * 512) / 1000))
             tips: 
           MFMA FLOPs (F16):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (EndNs - BeginNs)))
             unit: GFLOP
-            peak: ((($sclk * $numCU) * 4096) / 1000)
+            peak: ((($sclk * $numCU) * 1024) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 4096) / 1000))
+              / ((($sclk * $numCU) * 1024) / 1000))
             tips: 
           MFMA FLOPs (F32):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / (EndNs - BeginNs)))
@@ -72,9 +72,9 @@ Panel Config:
           MFMA IOPs (Int8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (EndNs - BeginNs)))
             unit: GIOP
-            peak: ((($sclk * $numCU) * 4096) / 1000)
+            peak: ((($sclk * $numCU) * 1024) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 4096) / 1000))
+              / ((($sclk * $numCU) * 1024) / 1000))
             tips: 
           Active CUs:
             value: $numActiveCUs

--- a/src/omniperf_analyze/configs/gfx90a/0200_system-speed-of-light.yaml
+++ b/src/omniperf_analyze/configs/gfx90a/0200_system-speed-of-light.yaml
@@ -44,16 +44,16 @@ Panel Config:
           MFMA FLOPs (BF16):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (EndNs - BeginNs)))
             unit: GFLOP
-            peak: ((($sclk * $numCU) * 512) / 1000)
+            peak: ((($sclk * $numCU) * 4096) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 512) / 1000))
+              / ((($sclk * $numCU) * 4096) / 1000))
             tips: 
           MFMA FLOPs (F16):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (EndNs - BeginNs)))
             unit: GFLOP
-            peak: ((($sclk * $numCU) * 1024) / 1000)
+            peak: ((($sclk * $numCU) * 4096) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 1024) / 1000))
+              / ((($sclk * $numCU) * 4096) / 1000))
             tips: 
           MFMA FLOPs (F32):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / (EndNs - BeginNs)))
@@ -72,9 +72,9 @@ Panel Config:
           MFMA IOPs (Int8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (EndNs - BeginNs)))
             unit: GIOP
-            peak: ((($sclk * $numCU) * 1024) / 1000)
+            peak: ((($sclk * $numCU) * 4096) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 1024) / 1000))
+              / ((($sclk * $numCU) * 4096) / 1000))
             tips: 
           Active CUs:
             value: $numActiveCUs

--- a/src/omniperf_analyze/configs/gfx940/0200_system-speed-of-light.yaml
+++ b/src/omniperf_analyze/configs/gfx940/0200_system-speed-of-light.yaml
@@ -44,16 +44,16 @@ Panel Config:
           MFMA FLOPs (BF16):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (EndNs - BeginNs)))
             unit: GFLOP
-            peak: ((($sclk * $numCU) * 512) / 1000)
+            peak: ((($sclk * $numCU) * 4096) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 512) / 1000))
+              / ((($sclk * $numCU) * 4096) / 1000))
             tips: 
           MFMA FLOPs (F16):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (EndNs - BeginNs)))
             unit: GFLOP
-            peak: ((($sclk * $numCU) * 1024) / 1000)
+            peak: ((($sclk * $numCU) * 4096) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 1024) / 1000))
+              / ((($sclk * $numCU) * 4096) / 1000))
             tips: 
           MFMA FLOPs (F32):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / (EndNs - BeginNs)))
@@ -72,9 +72,9 @@ Panel Config:
           MFMA IOPs (Int8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (EndNs - BeginNs)))
             unit: GIOP
-            peak: ((($sclk * $numCU) * 1024) / 1000)
+            peak: ((($sclk * $numCU) * 4096) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (EndNs - BeginNs))))
-              / ((($sclk * $numCU) * 1024) / 1000))
+              / ((($sclk * $numCU) * 4096) / 1000))
             tips: 
           Active CUs:
             value: $numActiveCUs


### PR DESCRIPTION
Similar to #155, from [AMD Matrix Calculator](https://github.com/RadeonOpenCompute/amd_matrix_instruction_calculator) we find we need to update op counts for System SOL dtypes