### PR TITLE
CMake - Load dependency check from requirements.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,20 +72,7 @@ if(DEFINED PYTHON_DEPS)
 endif()
 
 # Check required Python packages
-set(pythonDeps
-    "astunparse"
-    "colorlover"
-    "dash"
-    "matplotlib"
-    "numpy"
-    "pandas"
-    "pymongo"
-    "yaml"
-    "tabulate"
-    "tqdm"
-    "dash_svg"
-    "dash_bootstrap_components"
-    "kaleido")
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" pythonDeps)
 
 message(STATUS "Checking for required Python package dependencies...")
 set_property(GLOBAL PROPERTY pythonDepsFlag "groovy")
@@ -105,6 +92,7 @@ endfunction()
 
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 foreach(package IN LISTS pythonDeps)
+    string(REGEX REPLACE "[><=].*" "" package "${package}")
     checkpythonpackage(${package})
 endforeach()
 list(POP_BACK CMAKE_MESSAGE_INDENT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
 foreach(package IN LISTS pythonDeps)
     # Filter out any version requirements from requirements.txt
     string(REGEX REPLACE "[><=].*" "" package "${package}")
+    string(REPLACE "-" "_" package "${package}")
     checkpythonpackage(${package})
 endforeach()
 list(POP_BACK CMAKE_MESSAGE_INDENT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ endfunction()
 
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 foreach(package IN LISTS pythonDeps)
+    # Filter out any version requirements from requirements.txt
     string(REGEX REPLACE "[><=].*" "" package "${package}")
     checkpythonpackage(${package})
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,13 @@ message(STATUS "Checking for required Python package dependencies...")
 set_property(GLOBAL PROPERTY pythonDepsFlag "groovy")
 
 function(checkPythonPackage [package])
+    # mapping for non-default package names
+    set(PACKAGE ${ARGV0})
+    if(${ARGV0} STREQUAL "pyyaml")
+        set(PACKAGE "yaml")
+    endif()
     execute_process(
-        COMMAND ${Python3_EXECUTABLE} -c "import ${ARGV0}"
+        COMMAND ${Python3_EXECUTABLE} -c "import ${PACKAGE}"
         OUTPUT_QUIET ERROR_QUIET
         RESULT_VARIABLE EXIT_CODE)
     if(${EXIT_CODE} EQUAL 0)


### PR DESCRIPTION
I noticed this issue when submitting #200 which added a new Python module. I found that in our CMakeLists.txt, we're hardcoding a list of modules for the build script to check for
https://github.com/AMDResearch/omniperf/blob/df4d508a03e114d89c47b4e67888dc4273bcff3c/CMakeLists.txt#L74-L88

This PR changes that logic s.t. we now pull from the requirements.txt file. My CMake experience is  scarce, so I'm open to suggestions if there's a better way to do this