### PR TITLE
Remove use of `epoll` selector

### DIFF
--- a/src/omniperf_analyze/utils/gui.py
+++ b/src/omniperf_analyze/utils/gui.py
@@ -22,7 +22,6 @@
 # SOFTWARE.
 ##############################################################################el
 
-from selectors import EpollSelector
 import sys
 import copy
 import os.path


### PR DESCRIPTION
The epoll selector import was unused throughout the file, and is unsupported for certain operating systems (e.g. MacOS). This PR removes it.