### PR TITLE
CLI: fix mem chart and copy config from gfx942 to gfx940 and gfx941

### DIFF
--- a/src/omniperf_analyze/configs/gfx908/0300_mem_chart.yaml
+++ b/src/omniperf_analyze/configs/gfx908/0300_mem_chart.yaml
@@ -77,19 +77,19 @@ Panel Config:
             tips:
           VGPR:
             #alias: vgpr_
-            value: ROUND(AVG(vgpr), 0)
+            value: ROUND(AVG(Arch_VGPR), 0)
             tips:
           SGPR:
             #alias: sgpr_
-            value: ROUND(AVG(sgpr), 0)
+            value: ROUND(AVG(SGPR), 0)
             tips:
           LDS Allocation:
             #alias: lds_alloc_
-            value: ROUND(AVG(lds), 0)
+            value: ROUND(AVG(LDS_Per_Workgroup), 0)
             tips:
           Scratch Allocation:
             #alias: scratch_alloc_
-            value: ROUND(AVG(scr), 0)
+            value: ROUND(AVG(Scratch_Per_Workitem), 0)
             tips:
           Wavefronts:
             #alias: wavefronts_

--- a/src/omniperf_analyze/configs/gfx940/0200_system-speed-of-light.yaml
+++ b/src/omniperf_analyze/configs/gfx940/0200_system-speed-of-light.yaml
@@ -11,7 +11,6 @@ Panel Config:
   data source:
     - metric_table:
         id: 201
-        title: Speed-of-Light
         header:
           metric: Metric
           value: Value

--- a/src/omniperf_analyze/configs/gfx940/0300_mem_chart.yaml
+++ b/src/omniperf_analyze/configs/gfx940/0300_mem_chart.yaml
@@ -77,19 +77,20 @@ Panel Config:
             tips:
           VGPR:
             #alias: vgpr_
-            value: ROUND(AVG(vgpr), 0)
+            value: ROUND(AVG(Arch_VGPR), 0)
             tips:
+          # Todo: add AGPRs
           SGPR:
             #alias: sgpr_
-            value: ROUND(AVG(sgpr), 0)
+            value: ROUND(AVG(SGPR), 0)
             tips:
           LDS Allocation:
             #alias: lds_alloc_
-            value: ROUND(AVG(lds), 0)
+            value: ROUND(AVG(LDS_Per_Workgroup), 0)
             tips:
           Scratch Allocation:
             #alias: scratch_alloc_
-            value: ROUND(AVG(scr), 0)
+            value: ROUND(AVG(Scratch_Per_Workitem), 0)
             tips:
           Wavefronts:
             #alias: wavefronts_
@@ -254,16 +255,16 @@ Panel Config:
           L2 Rd Lat:
             #alias: l2_rd_lat_
             value:
-              ROUND(AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None)),
-              0)
+              # ROUND(AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None)),
+              # 0)
             tips:
           L2 Wr Lat:
             #alias: l2_wr_lat_
             value:
-              ROUND(AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum +
-              TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
-              != 0) else None)), 0)
+              # ROUND(AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum +
+              # TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+              # != 0) else None)), 0)
             tips:
 
           # ----------------------------------------

--- a/src/omniperf_analyze/configs/gfx940/0700_wavefront-launch.yaml
+++ b/src/omniperf_analyze/configs/gfx940/0700_wavefront-launch.yaml
@@ -20,65 +20,65 @@ Panel Config:
           tips: Tips
         metric:
           Grid Size:
-            avg: AVG(grd)
-            min: MIN(grd)
-            max: MAX(grd)
+            avg: AVG(Grid_Size)
+            min: MIN(Grid_Size)
+            max: MAX(Grid_Size)
             unit: Work Items
-            tips: 
+            tips:
           Workgroup Size:
-            avg: AVG(wgr)
-            min: MIN(wgr)
-            max: MAX(wgr)
+            avg: AVG(LDS_Per_Workgroup)
+            min: MIN(LDS_Per_Workgroup)
+            max: MAX(LDS_Per_Workgroup)
             unit: Work Items
-            tips: 
+            tips:
           Total Wavefronts:
             avg: AVG(SPI_CSN_WAVE)
             min: MIN(SPI_CSN_WAVE)
             max: MAX(SPI_CSN_WAVE)
             unit: Wavefronts
-            tips: 
+            tips:
           Saved Wavefronts:
             avg: AVG(SQ_WAVES_SAVED)
             min: MIN(SQ_WAVES_SAVED)
             max: MAX(SQ_WAVES_SAVED)
             unit: Wavefronts
-            tips: 
+            tips:
           Restored Wavefronts:
             avg: AVG(SQ_WAVES_RESTORED)
             min: MIN(SQ_WAVES_RESTORED)
             max: MAX(SQ_WAVES_RESTORED)
             unit: Wavefronts
-            tips: 
+            tips:
           VGPRs:
-            avg: AVG(arch_vgpr)
-            min: MIN(arch_vgpr)
-            max: MAX(arch_vgpr)
+            avg: AVG(Arch_VGPR)
+            min: MIN(Arch_VGPR)
+            max: MAX(Arch_VGPR)
             unit: Registers
-            tips: 
+            tips:
           AGPRs:
-            avg: AVG(accum_vgpr)
-            min: MIN(accum_vgpr)
-            max: MAX(accum_vgpr)
+            avg: AVG(Accum_VGPR)
+            min: MIN(Accum_VGPR)
+            max: MAX(Accum_VGPR)
             unit: Registers
-            tips: 
+            tips:
           SGPRs:
-            avg: AVG(sgpr)
-            min: MIN(sgpr)
-            max: MAX(sgpr)
+            avg: AVG(SGPR)
+            min: MIN(SGPR)
+            max: MAX(SGPR)
             unit: Registers
-            tips: 
+            tips:
           LDS Allocation:
-            avg: AVG(lds)
-            min: MIN(lds)
-            max: MAX(lds)
+            avg: AVG(LDS_Per_Workgroup)
+            min: MIN(LDS_Per_Workgroup)
+            max: MAX(LDS_Per_Workgroup)
             unit: Bytes
-            tips: 
+            tips:
           Scratch Allocation:
-            avg: AVG(scr)
-            min: MIN(scr)
-            max: MAX(scr)
+            avg: AVG(Scratch_Per_Workitem)
+            min: MIN(Scratch_Per_Workitem)
+            max: MAX(Scratch_Per_Workitem)
             unit: Bytes
-            tips: 
+            tips:
 
     - metric_table:
         id: 702
@@ -96,47 +96,47 @@ Panel Config:
             min: MIN((EndNs - BeginNs))
             max: MAX((EndNs - BeginNs))
             unit: ns
-            tips: 
+            tips:
           Kernel Time (Cycles):
             avg: AVG(GRBM_GUI_ACTIVE)
             min: MIN(GRBM_GUI_ACTIVE)
             max: MAX(GRBM_GUI_ACTIVE)
             unit: Cycle
-            tips: 
+            tips:
           Instr/wavefront:
             avg: AVG((SQ_INSTS / SQ_WAVES))
             min: MIN((SQ_INSTS / SQ_WAVES))
             max: MAX((SQ_INSTS / SQ_WAVES))
             unit: Instr/wavefront
-            tips: 
+            tips:
           Wave Cycles:
             avg: AVG(((4 * SQ_WAVE_CYCLES) / $denom))
             min: MIN(((4 * SQ_WAVE_CYCLES) / $denom))
             max: MAX(((4 * SQ_WAVE_CYCLES) / $denom))
             unit: (Cycles + $normUnit)
-            tips: 
+            tips:
           Dependency Wait Cycles:
             avg: AVG(((4 * SQ_WAIT_ANY) / $denom))
             min: MIN(((4 * SQ_WAIT_ANY) / $denom))
             max: MAX(((4 * SQ_WAIT_ANY) / $denom))
             unit: (Cycles + $normUnit)
-            tips: 
+            tips:
           Issue Wait Cycles:
             avg: AVG(((4 * SQ_WAIT_INST_ANY) / $denom))
             min: MIN(((4 * SQ_WAIT_INST_ANY) / $denom))
             max: MAX(((4 * SQ_WAIT_INST_ANY) / $denom))
             unit: (Cycles + $normUnit)
-            tips: 
+            tips:
           Active Cycles:
             avg: AVG(((4 * SQ_ACTIVE_INST_ANY) / $denom))
             min: MIN(((4 * SQ_ACTIVE_INST_ANY) / $denom))
             max: MAX(((4 * SQ_ACTIVE_INST_ANY) / $denom))
             unit: (Cycles + $normUnit)
-            tips: 
+            tips:
           Wavefront Occupancy:
             avg: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
             min: MIN((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
             max: MAX((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
             unit: Wavefronts
             coll_level: SQ_LEVEL_WAVES
-            tips:  
+            tips:

--- a/src/omniperf_analyze/configs/gfx940/1200_lds.yaml
+++ b/src/omniperf_analyze/configs/gfx940/1200_lds.yaml
@@ -22,14 +22,18 @@ Panel Config:
           Access Rate:
             value: AVG(((200 * SQ_ACTIVE_INST_LDS) / (GRBM_GUI_ACTIVE * $numCU)))
             tips:
-          Bandwith (Pct-of-Peak):
-            value: AVG((((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
+          Bandwidth (Pct-of-Peak):
+            value:
+              AVG((((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
               / (EndNs - BeginNs)) / (($sclk * $numCU) * 0.00128)))
             tips:
           Bank Conflict Rate:
-            value: AVG((((SQ_LDS_BANK_CONFLICT * 3.125) / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
+            value:
+              AVG((((SQ_LDS_BANK_CONFLICT * 3.125) / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
               if ((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) != 0) else None))
             tips:
+        comparable: false # for now
+        cli_style: simple_bar
 
     - metric_table:
         id: 1202
@@ -49,20 +53,26 @@ Panel Config:
             unit: (Instr  + $normUnit)
             tips:
           Bandwidth:
-            avg: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
+            avg:
+              AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
               / $denom))
-            min: MIN(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
+            min:
+              MIN(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
               / $denom))
-            max: MAX(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
+            max:
+              MAX(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
               / $denom))
             unit: (Bytes  + $normUnit)
             tips:
           Bank Conficts/Access:
-            avg: AVG(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
+            avg:
+              AVG(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
               if ((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) != 0) else None))
-            min: MIN(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
+            min:
+              MIN(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
               if ((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) != 0) else None))
-            max: MAX(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
+            max:
+              MAX(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
               if ((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) != 0) else None))
             unit: Conflicts/Access
             tips:
@@ -71,37 +81,37 @@ Panel Config:
             min: MIN((SQ_LDS_IDX_ACTIVE / $denom))
             max: MAX((SQ_LDS_IDX_ACTIVE / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Atomic Cycles:
             avg: AVG((SQ_LDS_ATOMIC_RETURN / $denom))
             min: MIN((SQ_LDS_ATOMIC_RETURN / $denom))
             max: MAX((SQ_LDS_ATOMIC_RETURN / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Bank Conflict:
             avg: AVG((SQ_LDS_BANK_CONFLICT / $denom))
             min: MIN((SQ_LDS_BANK_CONFLICT / $denom))
             max: MAX((SQ_LDS_BANK_CONFLICT / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Addr Conflict:
             avg: AVG((SQ_LDS_ADDR_CONFLICT / $denom))
             min: MIN((SQ_LDS_ADDR_CONFLICT / $denom))
             max: MAX((SQ_LDS_ADDR_CONFLICT / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Unaligned Stall:
             avg: AVG((SQ_LDS_UNALIGNED_STALL / $denom))
             min: MIN((SQ_LDS_UNALIGNED_STALL / $denom))
             max: MAX((SQ_LDS_UNALIGNED_STALL / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Mem Violations:
             avg: AVG((SQ_LDS_MEM_VIOLATIONS / $denom))
             min: MIN((SQ_LDS_MEM_VIOLATIONS / $denom))
             max: MAX((SQ_LDS_MEM_VIOLATIONS / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           LDS Latency:
             avg: AVG(((SQ_ACCUM_PREV_HIRES / SQ_INSTS_LDS) if (SQ_INSTS_LDS != 0) else None))
             min: MIN(((SQ_ACCUM_PREV_HIRES / SQ_INSTS_LDS) if (SQ_INSTS_LDS != 0) else None))

--- a/src/omniperf_analyze/configs/gfx940/1300_instruction-cache.yaml
+++ b/src/omniperf_analyze/configs/gfx940/1300_instruction-cache.yaml
@@ -19,11 +19,14 @@ Panel Config:
           Bandwidth:
             value: AVG(((SQC_ICACHE_REQ * 100000) / (($sclk * $numSQC)
               * (EndNs - BeginNs))))
-            tips: 
+            tips:
           Cache Hit:
-            value: AVG(((SQC_ICACHE_HITS * 100) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
+            value:
+              AVG(((SQC_ICACHE_HITS * 100) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
               + SQC_ICACHE_MISSES_DUPLICATE)))
-            tips: 
+            tips:
+        comparable: false # for now
+        cli_style: simple_bar
 
     - metric_table:
         id: 1302
@@ -37,35 +40,38 @@ Panel Config:
           tips: Tips
         metric:
           Req:
-            Avg: AVG((SQC_ICACHE_REQ / $denom))
+            avg: AVG((SQC_ICACHE_REQ / $denom))
             min: MIN((SQC_ICACHE_REQ / $denom))
             max: MAX((SQC_ICACHE_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Hits:
-            Avg: AVG((SQC_ICACHE_HITS / $denom))
+            avg: AVG((SQC_ICACHE_HITS / $denom))
             min: MIN((SQC_ICACHE_HITS / $denom))
             max: MAX((SQC_ICACHE_HITS / $denom))
             unit: (Hits  + $normUnit)
-            tips: 
+            tips:
           Misses - Non Duplicated:
-            Avg: AVG((SQC_ICACHE_MISSES / $denom))
+            avg: AVG((SQC_ICACHE_MISSES / $denom))
             min: MIN((SQC_ICACHE_MISSES / $denom))
             max: MAX((SQC_ICACHE_MISSES / $denom))
             unit: (Misses  + $normUnit)
-            tips: 
+            tips:
           Misses - Duplicated:
-            Avg: AVG((SQC_ICACHE_MISSES_DUPLICATE / $denom))
+            avg: AVG((SQC_ICACHE_MISSES_DUPLICATE / $denom))
             min: MIN((SQC_ICACHE_MISSES_DUPLICATE / $denom))
             max: MAX((SQC_ICACHE_MISSES_DUPLICATE / $denom))
             unit: (Misses  + $normUnit)
-            tips: 
+            tips:
           Cache Hit:
-            Avg: AVG(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
+            avg:
+              AVG(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
               + SQC_ICACHE_MISSES_DUPLICATE)))
-            min: MIN(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES) +
+            min:
+              MIN(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES) +
               SQC_ICACHE_MISSES_DUPLICATE)))
-            max: MAX(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES) +
+            max:
+              MAX(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES) +
               SQC_ICACHE_MISSES_DUPLICATE)))
             unit: pct
-            tips: 
+            tips:

--- a/src/omniperf_analyze/configs/gfx940/1400_constant-cache.yaml
+++ b/src/omniperf_analyze/configs/gfx940/1400_constant-cache.yaml
@@ -25,6 +25,8 @@ Panel Config:
               AVG((((SQC_DCACHE_HITS * 100) / (SQC_DCACHE_HITS + SQC_DCACHE_MISSES + SQC_DCACHE_MISSES_DUPLICATE))
               if ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES + SQC_DCACHE_MISSES_DUPLICATE) != 0) else None))
             tips:
+        comparable: false # for now
+        cli_style: simple_bar
 
     - metric_table:
         id: 1402
@@ -42,76 +44,82 @@ Panel Config:
             min: MIN((SQC_DCACHE_REQ / $denom))
             max: MAX((SQC_DCACHE_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Hits:
             avg: AVG((SQC_DCACHE_HITS / $denom))
             min: MIN((SQC_DCACHE_HITS / $denom))
             max: MAX((SQC_DCACHE_HITS / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Misses - Non Duplicated:
             avg: AVG((SQC_DCACHE_MISSES / $denom))
             min: MIN((SQC_DCACHE_MISSES / $denom))
             max: MAX((SQC_DCACHE_MISSES / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Misses- Duplicated:
             avg: AVG((SQC_DCACHE_MISSES_DUPLICATE / $denom))
             min: MIN((SQC_DCACHE_MISSES_DUPLICATE / $denom))
             max: MAX((SQC_DCACHE_MISSES_DUPLICATE / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Cache Hit:
-            avg: AVG((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
+            avg:
+              AVG((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE)) if (((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE) != 0) else None))
-            min: MIN((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
+            min:
+              MIN((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE)) if (((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE) != 0) else None))
-            max: MAX((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
+            max:
+              MAX((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE)) if (((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE) != 0) else None))
             unit: pct
-            tips: 
+            tips:
           Read Req (Total):
-            avg: AVG((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
+            avg:
+              AVG((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
               + SQC_DCACHE_REQ_READ_8) + SQC_DCACHE_REQ_READ_16) / $denom))
-            min: MIN((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
+            min:
+              MIN((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
               + SQC_DCACHE_REQ_READ_8) + SQC_DCACHE_REQ_READ_16) / $denom))
-            max: MAX((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
+            max:
+              MAX((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
               + SQC_DCACHE_REQ_READ_8) + SQC_DCACHE_REQ_READ_16) / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Atomic Req:
             avg: AVG((SQC_DCACHE_ATOMIC / $denom))
             min: MIN((SQC_DCACHE_ATOMIC / $denom))
             max: MAX((SQC_DCACHE_ATOMIC / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (1 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_1 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_1 / $denom))
             max: MAX((SQC_DCACHE_REQ_READ_1 / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (2 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_2 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_2 / $denom))
             max: MAX((SQC_DCACHE_REQ_READ_2 / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (4 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_4 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_4 / $denom))
             max: MAX((SQC_DCACHE_REQ_READ_4 / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (8 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_8 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_8 / $denom))
             max: MAX((SQC_DCACHE_REQ_READ_8 / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (16 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_16 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_16 / $denom))
@@ -135,22 +143,22 @@ Panel Config:
             min: MIN((SQC_TC_DATA_READ_REQ / $denom))
             max: MAX((SQC_TC_DATA_READ_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write Req:
             avg: AVG((SQC_TC_DATA_WRITE_REQ / $denom))
             min: MIN((SQC_TC_DATA_WRITE_REQ / $denom))
             max: MAX((SQC_TC_DATA_WRITE_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Atomic Req:
             avg: AVG((SQC_TC_DATA_ATOMIC_REQ / $denom))
             min: MIN((SQC_TC_DATA_ATOMIC_REQ / $denom))
             max: MAX((SQC_TC_DATA_ATOMIC_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Stall:
             avg: AVG((SQC_TC_STALL / $denom))
             min: MIN((SQC_TC_STALL / $denom))
             max: MAX((SQC_TC_STALL / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:

--- a/src/omniperf_analyze/configs/gfx940/1600_L1_cache.yaml
+++ b/src/omniperf_analyze/configs/gfx940/1600_L1_cache.yaml
@@ -17,80 +17,64 @@ Panel Config:
           tips: Tips
         metric:
           Buffer Coalescing:
-            value: AVG(((((TA_TOTAL_WAVEFRONTS_sum * 64) * 100) / (TCP_TOTAL_ACCESSES_sum
+            value:
+              AVG(((((TA_TOTAL_WAVEFRONTS_sum * 64) * 100) / (TCP_TOTAL_ACCESSES_sum
               * 4)) if (TCP_TOTAL_ACCESSES_sum != 0) else None))
-            tips: 
+            tips:
           Cache Util:
-            value: AVG((((TCP_GATE_EN2_sum * 100) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
+            value:
+              AVG((((TCP_GATE_EN2_sum * 100) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
               != 0) else None))
-            tips: 
+            tips:
           Cache BW:
-            value: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (EndNs - BeginNs))))
+            value:
+              ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (EndNs - BeginNs))))
               / ((($sclk / 1000) * 64) * $numCU))
-            tips: 
+            tips:
           Cache Hit:
-            value: AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            value:
+              AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
-               None))
-            tips: 
+              None))
+            tips:
+        comparable: false # for now
+        cli_style: simple_bar
 
     - metric_table:
         id: 1602
-        title: L1D Cache Stalls
+        title: L1D Cache Stalls (%)
         header:
           metric: Metric
-          mean: Mean
-          min: Min
-          max: Max
-          unit: unit
+          expr: Expression
           tips: Tips
         metric:
           Stalled on L2 Data:
-            mean: AVG((((100 * TCP_PENDING_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            min: MIN((((100 * TCP_PENDING_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            max: MAX((((100 * TCP_PENDING_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_PENDING_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
+              != 0) else None)
+            tips:
           Stalled on L2 Req:
-            mean: AVG((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            min: MIN((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            max: MAX((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
+              != 0) else None)
+            tips:
           Tag RAM Stall (Read):
-            mean: AVG((((100 * TCP_READ_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            min: MIN((((100 * TCP_READ_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            max: MAX((((100 * TCP_READ_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_READ_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
+              if (TCP_GATE_EN1_sum != 0) else None)
+            tips:
           Tag RAM Stall (Write):
-            mean: AVG((((100 * TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            min: MIN((((100 * TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            max: MAX((((100 * TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
+              if (TCP_GATE_EN1_sum != 0) else None)
+            tips:
           Tag RAM Stall (Atomic):
-            mean: AVG((((100 * TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            min: MIN((((100 * TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            max: MAX((((100 * TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
+              if (TCP_GATE_EN1_sum != 0) else None)
+            tips:
+        cli_style: simple_box
 
     - metric_table:
         id: 1603
@@ -108,25 +92,28 @@ Panel Config:
             min: MIN((TCP_TOTAL_ACCESSES_sum / $denom))
             max: MAX((TCP_TOTAL_ACCESSES_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req:
             avg: AVG((TCP_TOTAL_READ_sum / $denom))
             min: MIN((TCP_TOTAL_READ_sum / $denom))
             max: MAX((TCP_TOTAL_READ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write Req:
             avg: AVG((TCP_TOTAL_WRITE_sum / $denom))
             min: MIN((TCP_TOTAL_WRITE_sum / $denom))
             max: MAX((TCP_TOTAL_WRITE_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Atomic Req:
-            avg: AVG(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
+            avg:
+              AVG(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
               / $denom))
-            min: MIN(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
+            min:
+              MIN(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
               / $denom))
-            max: MAX(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
+            max:
+              MAX(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
               / $denom))
             unit: (Req  + $normUnit)
             tips:
@@ -141,44 +128,56 @@ Panel Config:
             min: MIN((TCP_TOTAL_CACHE_ACCESSES_sum / $denom))
             max: MAX((TCP_TOTAL_CACHE_ACCESSES_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Cache Hits:
-            avg: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            avg:
+              AVG(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / $denom))
-            min: MIN(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            min:
+              MIN(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / $denom))
-            max: MAX(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            max:
+              MAX(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Cache Hit Rate:
-            avg: AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
+            avg:
+              AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
               TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) /
               TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
-               None))
-            min: MIN(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
+              None))
+            min:
+              MIN(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
               TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) /
               TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
-               None))
-            max: MAX(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
+              None))
+            max:
+              MAX(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
               TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) /
               TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
-               None))
+              None))
             unit: pct
-            tips: 
+            tips:
           Invalidate:
             avg: AVG((TCP_TOTAL_WRITEBACK_INVALIDATES_sum / $denom))
             min: MIN((TCP_TOTAL_WRITEBACK_INVALIDATES_sum / $denom))
             max: MAX((TCP_TOTAL_WRITEBACK_INVALIDATES_sum / $denom))
             unit: (Req + $normUnit)
-            tips: 
+            tips:
           L1-L2 BW:
-            avg: AVG(((64 * (TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            min: MIN(((64 * (TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            max: MAX(((64 * (TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            avg:
+              AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
+              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            min:
+              AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
+              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            max:
+              AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
+              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
           L1-L2 Read:
@@ -186,52 +185,64 @@ Panel Config:
             min: MIN((TCP_TCC_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           L1-L2 Write:
             avg: AVG((TCP_TCC_WRITE_REQ_sum / $denom))
             min: MIN((TCP_TCC_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           L1-L2 Atomic:
-            avg: AVG(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            avg:
+              AVG(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
-            min: MIN(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            min:
+              MIN(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
-            max: MAX(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            max:
+              MAX(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           L1 Access Latency:
-            avg: AVG(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
-              != 0) else None))
-            min: MIN(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
-              != 0) else None))
-            max: MAX(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
-              != 0) else None))
+            avg:
+              # AVG(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
+              # != 0) else None))
+            min:
+              # MIN(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
+              # != 0) else None))
+            max:
+              # MAX(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
+              # != 0) else None))
             unit: Cycles
-            tips: 
+            tips:
           L1-L2 Read Latency:
-            avg: AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
-            min: MIN(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
-            max: MAX(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
+            avg:
+              # AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
+            min:
+              # MIN(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
+            max:
+              # MAX(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
             unit: Cycles
-            tips: 
+            tips:
           L1-L2 Write Latency:
-            avg: AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
-              if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
-              None))
-            min: MIN(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
-              if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
-              None))
-            max: MAX(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
-              if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
-              None))
+            avg:
+              # AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
+              # if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
+              # None))
+            min:
+              # MIN(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
+              # if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
+              # None))
+            max:
+              # MAX(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
+              # if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
+              # None))
             unit: Cycles
-            tips: 
+            tips:
 
     - metric_table:
         id: 1604
@@ -253,7 +264,7 @@ Panel Config:
             min: MIN((TCP_TCC_NC_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_NC_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           UC - Read:
             xfer: Read
             coherency: UC
@@ -261,7 +272,7 @@ Panel Config:
             min: MIN((TCP_TCC_UC_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_UC_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           CC - Read:
             xfer: Read
             coherency: CC
@@ -269,7 +280,7 @@ Panel Config:
             min: MIN((TCP_TCC_CC_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_CC_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           RW - Read:
             xfer: Read
             coherency: RW
@@ -277,7 +288,7 @@ Panel Config:
             min: MIN((TCP_TCC_RW_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_RW_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           RW - Write:
             xfer: Write
             coherency: RW
@@ -285,7 +296,7 @@ Panel Config:
             min: MIN((TCP_TCC_RW_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_RW_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           NC - Write:
             xfer: Write
             coherency: NC
@@ -293,7 +304,7 @@ Panel Config:
             min: MIN((TCP_TCC_NC_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_NC_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           UC - Write:
             xfer: Write
             coherency: UC
@@ -301,7 +312,7 @@ Panel Config:
             min: MIN((TCP_TCC_UC_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_UC_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           CC - Write:
             xfer: Write
             coherency: CC
@@ -309,7 +320,7 @@ Panel Config:
             min: MIN((TCP_TCC_CC_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_CC_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           NC - Atomic:
             xfer: Atomic
             coherency: NC
@@ -317,7 +328,7 @@ Panel Config:
             min: MIN((TCP_TCC_NC_ATOMIC_REQ_sum / $denom))
             max: MAX((TCP_TCC_NC_ATOMIC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           UC - Atomic:
             xfer: Atomic
             coherency: UC
@@ -325,7 +336,7 @@ Panel Config:
             min: MIN((TCP_TCC_UC_ATOMIC_REQ_sum / $denom))
             max: MAX((TCP_TCC_UC_ATOMIC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           CC - Atomic:
             xfer: Atomic
             coherency: CC
@@ -333,7 +344,7 @@ Panel Config:
             min: MIN((TCP_TCC_CC_ATOMIC_REQ_sum / $denom))
             max: MAX((TCP_TCC_CC_ATOMIC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           RW - Atomic:
             xfer: Atomic
             coherency: RW
@@ -341,7 +352,7 @@ Panel Config:
             min: MIN((TCP_TCC_RW_ATOMIC_REQ_sum / $denom))
             max: MAX((TCP_TCC_RW_ATOMIC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
 
     - metric_table:
         id: 1605
@@ -359,31 +370,34 @@ Panel Config:
             min: MIN((TCP_UTCL1_REQUEST_sum / $denom))
             max: MAX((TCP_UTCL1_REQUEST_sum / $denom))
             units: ( + $normUnit)
-            tips: 
+            tips:
           Hit Ratio:
-            avg: AVG((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
+            avg:
+              AVG((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
               (TCP_UTCL1_REQUEST_sum != 0) else None))
-            min: MIN((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
+            min:
+              MIN((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
               (TCP_UTCL1_REQUEST_sum != 0) else None))
-            max: MAX((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
+            max:
+              MAX((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
               (TCP_UTCL1_REQUEST_sum != 0) else None))
             units: pct
-            tips: 
+            tips:
           Hits:
             avg: AVG((TCP_UTCL1_TRANSLATION_HIT_sum / $denom))
             min: MIN((TCP_UTCL1_TRANSLATION_HIT_sum / $denom))
             max: MAX((TCP_UTCL1_TRANSLATION_HIT_sum / $denom))
             units: ( + $normUnit)
-            tips: 
+            tips:
           Misses (Translation):
             avg: AVG((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             max: MAX((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             units: ( + $normUnit)
-            tips: 
+            tips:
           Misses (Permission):
             avg: AVG((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             max: MAX((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             units: ( + $normUnit)
-            tips: 
+            tips:

--- a/src/omniperf_analyze/configs/gfx940/1700_L2_cache.yaml
+++ b/src/omniperf_analyze/configs/gfx940/1700_L2_cache.yaml
@@ -20,22 +20,25 @@ Panel Config:
           L2 Util:
             value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
             unit: pct
-            tips: 
+            tips:
           Cache Hit:
-            value: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            value:
+              AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else 0))
             unit: pct
-            tips: 
+            tips:
           L2-EA Rd BW:
-            value: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
+            value:
+              AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
               * 64)) / (EndNs - BeginNs)))
             unit: GB/s
-            tips: 
+            tips:
           L2-EA Wr BW:
-            value: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
+            value:
+              AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
               * 32)) / (EndNs - BeginNs)))
             unit: GB/s
-            tips: 
+            tips:
 
     - metric_table:
         id: 1702
@@ -49,122 +52,143 @@ Panel Config:
           tips: Tips
         metric:
           Read BW:
-            avg: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
+            avg:
+              AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
               * 64)) / $denom))
-            min: MIN((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
+            min:
+              MIN((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
               * 64)) / $denom))
-            max: MAX((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
+            max:
+              MAX((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
               * 64)) / $denom))
             unit: (Bytes  + $normUnit)
-            tips: 
+            tips:
           Write BW:
-            avg: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
+            avg:
+              AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
               * 32)) / $denom))
-            min: MIN((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
+            min:
+              MIN((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
               * 32)) / $denom))
-            max: MAX((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
+            max:
+              MAX((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
               * 32)) / $denom))
             unit: (Bytes  + $normUnit)
-            tips: 
+            tips:
           Read (32B):
             avg: AVG((TCC_EA0_RDREQ_32B_sum / $denom))
             min: MIN((TCC_EA0_RDREQ_32B_sum / $denom))
             max: MAX((TCC_EA0_RDREQ_32B_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read (Uncached 32B):
             avg: AVG((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
             min: MIN((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
             max: MAX((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read (64B):
             avg: AVG(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
             min: MIN(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
             max: MAX(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           HBM Read:
             avg: AVG((TCC_EA0_RDREQ_DRAM_sum / $denom))
             min: MIN((TCC_EA0_RDREQ_DRAM_sum / $denom))
             max: MAX((TCC_EA0_RDREQ_DRAM_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write (32B):
             avg: AVG(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             min: MIN(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             max: MAX(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write (Uncached 32B):
             avg: AVG((TCC_EA0_WR_UNCACHED_32B_sum / $denom))
             min: MIN((TCC_EA0_WR_UNCACHED_32B_sum / $denom))
             max: MAX((TCC_EA0_WR_UNCACHED_32B_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write (64B):
             avg: AVG((TCC_EA0_WRREQ_64B_sum / $denom))
             min: MIN((TCC_EA0_WRREQ_64B_sum / $denom))
             max: MAX((TCC_EA0_WRREQ_64B_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           HBM Write:
             avg: AVG((TCC_EA0_WRREQ_DRAM_sum / $denom))
             min: MIN((TCC_EA0_WRREQ_DRAM_sum / $denom))
             max: MAX((TCC_EA0_WRREQ_DRAM_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Latency:
-            avg: AVG(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
+            avg:
+              AVG(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
               0) else None))
-            min: MIN(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
+            min:
+              MIN(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
               0) else None))
-            max: MAX(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
+            max:
+              MAX(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
               0) else None))
             unit: Cycles
-            tips: 
+            tips:
           Write Latency:
-            avg: AVG(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
+            avg:
+              AVG(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
               0) else None))
-            min: MIN(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
+            min:
+              MIN(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
               0) else None))
-            max: MAX(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
+            max:
+              MAX(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
               0) else None))
             unit: Cycles
-            tips: 
+            tips:
           Atomic Latency:
-            avg: AVG(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
+            avg:
+              AVG(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
               != 0) else None))
-            min: MIN(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
+            min:
+              MIN(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
               != 0) else None))
-            max: MAX(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
+            max:
+              MAX(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
               != 0) else None))
             unit: Cycles
-            tips: 
+            tips:
           Read Stall:
-            avg: AVG((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
-            min: MIN((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
-            max: MAX((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
+            avg:
+              # AVG((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
+            min:
+              # MIN((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
+            max:
+              # MAX((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
             unit: pct
-            tips: 
+            tips:
           Write Stall:
-            avg: AVG((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
-            min: MIN((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
-            max: MAX((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
+            avg:
+              # AVG((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
+            min:
+              # MIN((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
+            max:
+              # MAX((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
             unit: pct
-            tips: 
+            tips:
 
     - metric_table:
         id: 1703
@@ -182,112 +206,115 @@ Panel Config:
             min: MIN((TCC_REQ_sum / $denom))
             max: MAX((TCC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Streaming Req:
             avg: AVG((TCC_STREAMING_REQ_sum / $denom))
             min: MIN((TCC_STREAMING_REQ_sum / $denom))
             max: MAX((TCC_STREAMING_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req:
             avg: AVG((TCC_READ_sum / $denom))
             min: MIN((TCC_READ_sum / $denom))
             max: MAX((TCC_READ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write Req:
             avg: AVG((TCC_WRITE_sum / $denom))
             min: MIN((TCC_WRITE_sum / $denom))
             max: MAX((TCC_WRITE_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Atomic Req:
             avg: AVG((TCC_ATOMIC_sum / $denom))
             min: MIN((TCC_ATOMIC_sum / $denom))
             max: MAX((TCC_ATOMIC_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Probe Req:
             avg: AVG((TCC_PROBE_sum / $denom))
             min: MIN((TCC_PROBE_sum / $denom))
             max: MAX((TCC_PROBE_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Hits:
             avg: AVG((TCC_HIT_sum / $denom))
             min: MIN((TCC_HIT_sum / $denom))
             max: MAX((TCC_HIT_sum / $denom))
             unit: (Hits  + $normUnit)
-            tips: 
+            tips:
           Misses:
             avg: AVG((TCC_MISS_sum / $denom))
             min: MIN((TCC_MISS_sum / $denom))
             max: MAX((TCC_MISS_sum / $denom))
             unit: (Misses  + $normUnit)
-            tips: 
+            tips:
           Cache Hit:
-            avg: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            avg:
+              AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else None))
-            min: MIN((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            min:
+              MIN((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else None))
-            max: MAX((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            max:
+              MAX((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else None))
             unit: pct
-            tips: 
+            tips:
           Writeback:
             avg: AVG((TCC_WRITEBACK_sum / $denom))
             min: MIN((TCC_WRITEBACK_sum / $denom))
             max: MAX((TCC_WRITEBACK_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           NC Req:
             avg: AVG((TCC_NC_REQ_sum / $denom))
             min: MIN((TCC_NC_REQ_sum / $denom))
             max: MAX((TCC_NC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           UC Req:
             avg: AVG((TCC_UC_REQ_sum / $denom))
             min: MIN((TCC_UC_REQ_sum / $denom))
             max: MAX((TCC_UC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           CC Req:
             avg: AVG((TCC_CC_REQ_sum / $denom))
             min: MIN((TCC_CC_REQ_sum / $denom))
             max: MAX((TCC_CC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           RW Req:
             avg: AVG((TCC_RW_REQ_sum / $denom))
             min: MIN((TCC_RW_REQ_sum / $denom))
             max: MAX((TCC_RW_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Writeback (Normal):
             avg: AVG((TCC_NORMAL_WRITEBACK_sum / $denom))
             min: MIN((TCC_NORMAL_WRITEBACK_sum / $denom))
             max: MAX((TCC_NORMAL_WRITEBACK_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           Writeback (TC Req):
             avg: AVG((TCC_ALL_TC_OP_WB_WRITEBACK_sum / $denom))
             min: MIN((TCC_ALL_TC_OP_WB_WRITEBACK_sum / $denom))
             max: MAX((TCC_ALL_TC_OP_WB_WRITEBACK_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           Evict (Normal):
             avg: AVG((TCC_NORMAL_EVICT_sum / $denom))
             min: MIN((TCC_NORMAL_EVICT_sum / $denom))
             max: MAX((TCC_NORMAL_EVICT_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           Evict (TC Req):
             avg: AVG((TCC_ALL_TC_OP_INV_EVICT_sum / $denom))
             min: MIN((TCC_ALL_TC_OP_INV_EVICT_sum / $denom))
             max: MAX((TCC_ALL_TC_OP_INV_EVICT_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
 
     - metric_table:
         id: 1704
@@ -305,51 +332,51 @@ Panel Config:
           Read - Remote Socket Stall:
             type: Remote Socket Stall
             transaction: Read
-            avg: AVG((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read - Peer GCD Stall:
             type: Peer GCD Stall
             transaction: Read
-            avg: AVG((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read - HBM Stall:
             type: HBM Stall
             transaction: Read
-            avg: AVG((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write - Remote Socket Stall:
             type: Remote Socket Stall
             transaction: Write
-            avg: AVG((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write - Peer GCD Stall:
             type: Peer GCD Stall
             transaction: Write
-            avg: AVG((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write - HBM Stall:
             type: HBM Stall
             transaction: Write
-            avg: AVG((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write - Credit Starvation:
             type: Credit Starvation
             transaction: Write
@@ -357,4 +384,4 @@ Panel Config:
             min: MIN((TCC_TOO_MANY_EA_WRREQS_STALL_sum / $denom))
             max: MAX((TCC_TOO_MANY_EA_WRREQS_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:

--- a/src/omniperf_analyze/configs/gfx940/1800_L2_cache_per_channel.yaml
+++ b/src/omniperf_analyze/configs/gfx940/1800_L2_cache_per_channel.yaml
@@ -117,7 +117,7 @@ Panel Config:
               (((100 * TCC_HIT[::_1]) / (TCC_HIT[::_1] + TCC_MISS[::_1])) if ((TCC_HIT[::_1]
               + TCC_MISS[::_1]) != 0) else None)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -130,7 +130,7 @@ Panel Config:
           "::_1":
             expr: (TO_INT(TCC_REQ[::_1]) / $denom)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -147,7 +147,7 @@ Panel Config:
             write req: AVG((TO_INT(TCC_WRITE[::_1]) / $denom))
             atomic req: AVG((TO_INT(TCC_ATOMIC[::_1]) / $denom))
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_multiple_bar
 
     - metric_table:
@@ -160,11 +160,11 @@ Panel Config:
           atomic req: L2-EA Atomic
         metric:
           "::_1":
-            read req: AVG((TO_INT(TCC_EA_RDREQ[::_1]) / $denom))
-            write req: AVG((TO_INT(TCC_EA_WRREQ[::_1]) / $denom))
-            atomic req: AVG((TO_INT(TCC_EA_ATOMIC[::_1]) / $denom))
+            read req: AVG((TO_INT(TCC_EA0_RDREQ[::_1]) / $denom))
+            write req: AVG((TO_INT(TCC_EA0_WRREQ[::_1]) / $denom))
+            atomic req: AVG((TO_INT(TCC_EA0_ATOMIC[::_1]) / $denom))
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_multiple_bar
 
     # - metric_table:
@@ -178,16 +178,16 @@ Panel Config:
     #     metric:
     #       "::_1":
     #         read lat:
-    #           AVG(((TCC_EA_RDREQ_LEVEL[::_1] / TCC_EA_RDREQ[::_1]) if (TCC_EA_RDREQ[::_1]
+    #           AVG(((TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]) if (TCC_EA0_RDREQ[::_1]
     #           != 0) else None))
     #         write lat:
-    #           AVG(((TCC_EA_WRREQ_LEVEL[::_1] / TCC_EA_WRREQ[::_1]) if (TCC_EA_WRREQ[::_1]
+    #           AVG(((TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]) if (TCC_EA0_WRREQ[::_1]
     #           != 0) else None))
     #         atomic lat:
-    #           AVG(((TCC_EA_ATOMIC_LEVEL[::_1] / TCC_EA_ATOMIC[::_1]) if
-    #           (TCC_EA_ATOMIC[::_1] != 0) else 0))
+    #           AVG(((TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1]) if
+    #           (TCC_EA0_ATOMIC[::_1] != 0) else 0))
     #       placeholder_range:
-    #         "::_1": 96
+    #         "::_1": $totalL2Banks
     #     cli_style: simple_multiple_bar
 
     - metric_table:
@@ -199,10 +199,10 @@ Panel Config:
         metric:
           "::_1":
             expr:
-              ((TCC_EA_RDREQ_LEVEL[::_1] / TCC_EA_RDREQ[::_1]) if (TCC_EA_RDREQ[::_1]
+              ((TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]) if (TCC_EA0_RDREQ[::_1]
               != 0) else None)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -214,10 +214,10 @@ Panel Config:
         metric:
           "::_1":
             expr:
-              ((TCC_EA_WRREQ_LEVEL[::_1] / TCC_EA_WRREQ[::_1]) if (TCC_EA_WRREQ[::_1]
+              ((TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]) if (TCC_EA0_WRREQ[::_1]
               != 0) else None)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -228,10 +228,10 @@ Panel Config:
           expr: Expression
         metric:
           "::_1":
-            expr: ((TCC_EA_ATOMIC_LEVEL[::_1] / TCC_EA_ATOMIC[::_1]) if
-              (TCC_EA_ATOMIC[::_1] != 0) else 0)
+            expr: ((TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1]) if
+              (TCC_EA0_ATOMIC[::_1] != 0) else 0)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -244,11 +244,11 @@ Panel Config:
           ea read stall - dram: L2-EA Read Stall - DRAM
         metric:
           "::_1":
-            ea read stall - io: AVG((TO_INT(TCC_EA_RDREQ_IO_CREDIT_STALL[::_1]) / $denom))
-            ea read stall - gmi: AVG((TO_INT(TCC_EA_RDREQ_GMI_CREDIT_STALL[::_1]) / $denom))
-            ea read stall - dram: AVG((TO_INT(TCC_EA_RDREQ_DRAM_CREDIT_STALL[::_1]) / $denom))
+            ea read stall - io: AVG((TO_INT(TCC_EA0_RDREQ_IO_CREDIT_STALL[::_1]) / $denom))
+            ea read stall - gmi: AVG((TO_INT(TCC_EA0_RDREQ_GMI_CREDIT_STALL[::_1]) / $denom))
+            ea read stall - dram: AVG((TO_INT(TCC_EA0_RDREQ_DRAM_CREDIT_STALL[::_1]) / $denom))
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_multiple_bar
 
     - metric_table:
@@ -262,10 +262,37 @@ Panel Config:
           ea write stall - starve: L2-EA Write Stall - Starve
         metric:
           "::_1":
-            ea write stall - io: AVG((TO_INT(TCC_EA_WRREQ_IO_CREDIT_STALL[::_1]) / $denom))
-            ea write stall - gmi: AVG((TO_INT(TCC_EA_WRREQ_GMI_CREDIT_STALL[::_1]) / $denom))
-            ea write stall - dram: AVG((TO_INT(TCC_EA_WRREQ_DRAM_CREDIT_STALL[::_1]) / $denom))
-            ea write stall - starve: AVG((TO_INT(TCC_TOO_MANY_EA_WRREQS_STALL[::_1]) / $denom))
+            ea write stall - io: AVG((TO_INT(TCC_EA0_WRREQ_IO_CREDIT_STALL[::_1]) / $denom))
+            ea write stall - gmi: AVG((TO_INT(TCC_EA0_WRREQ_GMI_CREDIT_STALL[::_1]) / $denom))
+            ea write stall - dram: AVG((TO_INT(TCC_EA0_WRREQ_DRAM_CREDIT_STALL[::_1]) / $denom))
+            ea write stall - starve: AVG((TO_INT(TCC_TOO_MANY_EA0_WRREQS_STALL[::_1]) / $denom))
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_multiple_bar
+
+    - metric_table:
+        id: 1811
+        title: L2 Tag Stall (cycles)
+        header:
+          metric: Metric
+          expr: Expression
+        metric:
+          "::_1":
+            expr: TCC_TAG_STALL[::_1]
+          placeholder_range:
+            "::_1": $totalL2Banks
+        cli_style: simple_box
+
+    - metric_table:
+        id: 1812
+        title: L2 Bubble (128B request)
+        header:
+          metric: Metric
+          expr: Expression
+        metric:
+          "::_1":
+            expr: TCC_BUBBLE[::_1]
+          placeholder_range:
+            "::_1": $totalL2Banks
+          # tips: Number of 128-byte read requests sent to EA
+        cli_style: simple_box

--- a/src/omniperf_analyze/configs/gfx940/1900_memory_chart.yaml
+++ b/src/omniperf_analyze/configs/gfx940/1900_memory_chart.yaml
@@ -18,241 +18,256 @@ Panel Config:
           tips: Tips
         metric:
           Wave Life:
-            value: ROUND(AVG(((4 * (SQ_WAVE_CYCLES / SQ_WAVES)) if (SQ_WAVES != 0) else
+            value:
+              ROUND(AVG(((4 * (SQ_WAVE_CYCLES / SQ_WAVES)) if (SQ_WAVES != 0) else
               None)), 0)
             alias: wave_life_
-            tips: 
+            tips:
           Active CUs:
             value: CONCAT(CONCAT($numActiveCUs, "/"), $numCU)
             alias: active_cu_
-            tips: 
+            tips:
           SALU:
             value: ROUND(AVG((SQ_INSTS_SALU / $denom)), 0)
             alias: salu_
-            tips: 
+            tips:
           SMEM:
             value: ROUND(AVG((SQ_INSTS_SMEM / $denom)), 0)
             alias: smem_
-            tips: 
+            tips:
           VALU:
             value: ROUND(AVG((SQ_INSTS_VALU / $denom)), 0)
             alias: valu_
-            tips: 
+            tips:
           MFMA:
             value: ROUND(AVG((SQ_INSTS_MFMA / $denom)), 0)
             alias: mfma_
-            tips: 
+            tips:
           VMEM:
             value: ROUND(AVG((SQ_INSTS_VMEM / $denom)), 0)
             alias: vmem_
-            tips: 
+            tips:
           LDS:
             value: ROUND(AVG((SQ_INSTS_LDS / $denom)), 0)
             alias: lds_
-            tips: 
+            tips:
           GWS:
             value: ROUND(AVG((SQ_INSTS_GDS / $denom)), 0)
             alias: gws_
-            tips: 
+            tips:
           BR:
             value: ROUND(AVG((SQ_INSTS_BRANCH / $denom)), 0)
             alias: br_
-            tips: 
+            tips:
           VGPR:
             value: ROUND(AVG(vgpr), 0)
             alias: vgpr_
-            tips: 
+            tips:
           SGPR:
             value: ROUND(AVG(sgpr), 0)
             alias: sgpr_
-            tips: 
+            tips:
           LDS Allocation:
             value: ROUND(AVG(lds), 0)
             alias: lds_alloc_
-            tips: 
+            tips:
           Scratch Allocation:
             value: ROUND(AVG(scr), 0)
             alias: scratch_alloc_
-            tips: 
+            tips:
           Wavefronts:
             value: ROUND(AVG(SPI_CSN_WAVE), 0)
             alias: wavefronts_
-            tips: 
+            tips:
           Workgroups:
             value: ROUND(AVG(SPI_CSN_NUM_THREADGROUPS), 0)
             alias: workgroups_
-            tips: 
+            tips:
           LDS Req:
             value: ROUND(AVG((SQ_INSTS_LDS / $denom)), 0)
             alias: lds_req_
-            tips: 
+            tips:
           IL1 Fetch:
             value: ROUND(AVG((SQC_ICACHE_REQ / $denom)), 0)
             alias: il1_fetch_
-            tips: 
+            tips:
           IL1 Hit:
             value: ROUND((AVG((SQC_ICACHE_HITS / SQC_ICACHE_REQ)) * 100), 0)
             alias: il1_hit_
-            tips: 
+            tips:
           IL1_L2 Rd:
             value: ROUND(AVG((SQC_TC_INST_REQ / $denom)), 0)
             alias: il1_l2_req_
-            tips: 
+            tips:
           vL1D Rd:
             value: ROUND(AVG((SQC_DCACHE_REQ / $denom)), 0)
             alias: sl1_rd_
-            tips: 
+            tips:
           vL1D Hit:
-            value: ROUND((AVG(((SQC_DCACHE_HITS / SQC_DCACHE_REQ) if (SQC_DCACHE_REQ !=
+            value:
+              ROUND((AVG(((SQC_DCACHE_HITS / SQC_DCACHE_REQ) if (SQC_DCACHE_REQ !=
               0) else None)) * 100), 0)
             alias: sl1_hit_
-            tips: 
+            tips:
           vL1D_L2 Rd:
             value: ROUND(AVG((SQC_TC_DATA_READ_REQ / $denom)), 0)
             alias: sl1_l2_rd_
-            tips: 
+            tips:
           vL1D_L2 Wr:
             value: ROUND(AVG((SQC_TC_DATA_WRITE_REQ / $denom)), 0)
             alias: sl1_l2_wr_
-            tips: 
+            tips:
           vL1D_L2 Atomic:
             value: ROUND(AVG((SQC_TC_DATA_ATOMIC_REQ / $denom)), 0)
             alias: sl1_l2_atom_
-            tips: 
+            tips:
           VL1 Rd:
             value: ROUND(AVG((TCP_TOTAL_READ_sum / $denom)), 0)
             alias: vl1_rd_
-            tips: 
+            tips:
           VL1 Wr:
             value: ROUND(AVG((TCP_TOTAL_WRITE_sum / $denom)), 0)
             alias: vl1_wr_
-            tips: 
+            tips:
           VL1 Atomic:
-            value: ROUND(AVG(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
+            value:
+              ROUND(AVG(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
               / $denom)), 0)
             alias: vl1_atom_
-            tips: 
+            tips:
           VL1 Hit:
-            value: ROUND(AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            value:
+              ROUND(AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
               None)), 0)
             alias: vl1_hit_
-            tips: 
+            tips:
           VL1 Lat:
-            value: ROUND(AVG(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
-              != 0) else None)), 0)
+            value:
+              # ROUND(AVG(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
+              # != 0) else None)), 0)
             alias: vl1_lat_
-            tips: 
+            tips:
           VL1_L2 Rd:
             value: ROUND(AVG((TCP_TCC_READ_REQ_sum / $denom)), 0)
             alias: vl1_l2_rd_
-            tips: 
+            tips:
           VL1_L2 Wr:
             value: ROUND(AVG((TCP_TCC_WRITE_REQ_sum / $denom)), 0)
             alias: vl1_l2_wr_
-            tips: 
+            tips:
           vL1_L2 Atomic:
-            value: ROUND(AVG(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            value:
+              ROUND(AVG(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom)), 0)
             alias: vl1_l2_atom_
-            tips: 
+            tips:
           L2 Rd:
             value: ROUND(AVG((TCC_READ_sum / $denom)), 0)
             alias: l2_rd_
-            tips: 
+            tips:
           L2 Wr:
             value: ROUND(AVG((TCC_WRITE_sum / $denom)), 0)
             alias: l2_wr_
-            tips: 
+            tips:
           L2 Atomic:
             value: ROUND(AVG((TCC_ATOMIC_sum / $denom)), 0)
             alias: l2_atom_
-            tips: 
+            tips:
           L2 Hit:
-            value: ROUND(AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            value:
+              ROUND(AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else None)), 0)
             alias: l2_hit_
-            tips: 
+            tips:
           L2 Rd Lat:
-            value: ROUND(AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None)),
-              0)
+            value:
+              # ROUND(AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None)),
+              # 0)
             alias: l2_rd_lat_
-            tips: 
+            tips:
           L2 Wr Lat:
-            value: ROUND(AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum +
-              TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
-              != 0) else None)), 0)
+            value:
+            # ROUND(AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum +
+            #   TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            #   != 0) else None)), 0)
             alias: l2_wr_lat_
-            tips: 
+            tips:
           Fabric Rd Lat:
-            value: ROUND(AVG(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum
+            value:
+              ROUND(AVG(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum
               != 0) else None)), 0)
             alias: fabric_rd_lat_
-            tips: 
+            tips:
           Fabric Wr Lat:
-            value: ROUND(AVG(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum
+            value:
+              ROUND(AVG(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum
               != 0) else None)), 0)
             alias: fabric_wr_lat_
-            tips: 
+            tips:
           Fabric Atomic Lat:
-            value: ROUND(AVG(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
+            value:
+              ROUND(AVG(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
               != 0) else None)), 0)
             alias: fabric_atom_lat_
-            tips: 
+            tips:
           Fabric_L2 Rd:
             value: ROUND(AVG((TCC_EA0_RDREQ_sum / $denom)), 0)
             alias: l2_fabric_rd_
-            tips: 
+            tips:
           Fabric_L2 Wr:
             value: ROUND(AVG((TCC_EA0_WRREQ_sum / $denom)), 0)
             alias: l2_fabric_wr_
-            tips: 
+            tips:
           Fabric_l2 Atomic:
             value: ROUND(AVG((TCC_EA0_ATOMIC_sum / $denom)), 0)
             alias: l2_fabric_atom_
-            tips: 
+            tips:
           HBM Rd:
             value: ROUND(AVG((TCC_EA0_RDREQ_DRAM_sum / $denom)), 0)
             alias: hbm_rd_
-            tips: 
+            tips:
           HBM Wr:
             value: ROUND(AVG((TCC_EA0_WRREQ_DRAM_sum / $denom)), 0)
             alias: hbm_wr_
-            tips: 
+            tips:
           LDS Util:
-            value: ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
+            value:
+              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
               0)
             alias: lds_util_
-            tips: 
+            tips:
           VL1 Coalesce:
-            value: ROUND(AVG(((((TA_TOTAL_WAVEFRONTS_sum * 64) * 100) / (TCP_TOTAL_ACCESSES_sum
+            value:
+              ROUND(AVG(((((TA_TOTAL_WAVEFRONTS_sum * 64) * 100) / (TCP_TOTAL_ACCESSES_sum
               * 4)) if (TCP_TOTAL_ACCESSES_sum != 0) else 0)), 0)
             alias: vl1_coales_
-            tips: 
+            tips:
           VL1 Stall:
-            value: ROUND(AVG((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) 
+            value:
+              ROUND(AVG((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
               if (TCP_GATE_EN1_sum != 0) else None)), 0)
             alias: vl1_stall_
-            tips: 
+            tips:
           LDS Lat:
-            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQ_INSTS_LDS) 
+            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQ_INSTS_LDS)
               if (SQ_INSTS_LDS != 0) else None)), 0)
             alias: lds_lat_
             coll_level: SQ_INST_LEVEL_LDS
             tips:
-          vL1D Lat: 
-            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQC_DCACHE_REQ) 
+          vL1D Lat:
+            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQC_DCACHE_REQ)
               if (SQC_DCACHE_REQ != 0) else None)), 0)
             alias: sl1_lat_
             tips:
-          IL1 Lat: 
-            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQC_ICACHE_REQ) 
+          IL1 Lat:
+            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQC_ICACHE_REQ)
               if (SQC_ICACHE_REQ != 0) else None)), 0)
             alias: il1_lat_
             tips:
-          Wave Occupancy: 
+          Wave Occupancy:
             value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / $numActiveCUs)), 0)
             alias: wave_occ_
             coll_level: SQ_LEVEL_WAVES

--- a/src/omniperf_analyze/configs/gfx941/0200_system-speed-of-light.yaml
+++ b/src/omniperf_analyze/configs/gfx941/0200_system-speed-of-light.yaml
@@ -11,7 +11,6 @@ Panel Config:
   data source:
     - metric_table:
         id: 201
-        title: Speed-of-Light
         header:
           metric: Metric
           value: Value

--- a/src/omniperf_analyze/configs/gfx941/0300_mem_chart.yaml
+++ b/src/omniperf_analyze/configs/gfx941/0300_mem_chart.yaml
@@ -77,19 +77,20 @@ Panel Config:
             tips:
           VGPR:
             #alias: vgpr_
-            value: ROUND(AVG(vgpr), 0)
+            value: ROUND(AVG(Arch_VGPR), 0)
             tips:
+          # Todo: add AGPRs
           SGPR:
             #alias: sgpr_
-            value: ROUND(AVG(sgpr), 0)
+            value: ROUND(AVG(SGPR), 0)
             tips:
           LDS Allocation:
             #alias: lds_alloc_
-            value: ROUND(AVG(lds), 0)
+            value: ROUND(AVG(LDS_Per_Workgroup), 0)
             tips:
           Scratch Allocation:
             #alias: scratch_alloc_
-            value: ROUND(AVG(scr), 0)
+            value: ROUND(AVG(Scratch_Per_Workitem), 0)
             tips:
           Wavefronts:
             #alias: wavefronts_
@@ -254,16 +255,16 @@ Panel Config:
           L2 Rd Lat:
             #alias: l2_rd_lat_
             value:
-              ROUND(AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None)),
-              0)
+              # ROUND(AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None)),
+              # 0)
             tips:
           L2 Wr Lat:
             #alias: l2_wr_lat_
             value:
-              ROUND(AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum +
-              TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
-              != 0) else None)), 0)
+              # ROUND(AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum +
+              # TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+              # != 0) else None)), 0)
             tips:
 
           # ----------------------------------------

--- a/src/omniperf_analyze/configs/gfx941/0700_wavefront-launch.yaml
+++ b/src/omniperf_analyze/configs/gfx941/0700_wavefront-launch.yaml
@@ -20,65 +20,65 @@ Panel Config:
           tips: Tips
         metric:
           Grid Size:
-            avg: AVG(grd)
-            min: MIN(grd)
-            max: MAX(grd)
+            avg: AVG(Grid_Size)
+            min: MIN(Grid_Size)
+            max: MAX(Grid_Size)
             unit: Work Items
-            tips: 
+            tips:
           Workgroup Size:
-            avg: AVG(wgr)
-            min: MIN(wgr)
-            max: MAX(wgr)
+            avg: AVG(LDS_Per_Workgroup)
+            min: MIN(LDS_Per_Workgroup)
+            max: MAX(LDS_Per_Workgroup)
             unit: Work Items
-            tips: 
+            tips:
           Total Wavefronts:
             avg: AVG(SPI_CSN_WAVE)
             min: MIN(SPI_CSN_WAVE)
             max: MAX(SPI_CSN_WAVE)
             unit: Wavefronts
-            tips: 
+            tips:
           Saved Wavefronts:
             avg: AVG(SQ_WAVES_SAVED)
             min: MIN(SQ_WAVES_SAVED)
             max: MAX(SQ_WAVES_SAVED)
             unit: Wavefronts
-            tips: 
+            tips:
           Restored Wavefronts:
             avg: AVG(SQ_WAVES_RESTORED)
             min: MIN(SQ_WAVES_RESTORED)
             max: MAX(SQ_WAVES_RESTORED)
             unit: Wavefronts
-            tips: 
+            tips:
           VGPRs:
-            avg: AVG(arch_vgpr)
-            min: MIN(arch_vgpr)
-            max: MAX(arch_vgpr)
+            avg: AVG(Arch_VGPR)
+            min: MIN(Arch_VGPR)
+            max: MAX(Arch_VGPR)
             unit: Registers
-            tips: 
+            tips:
           AGPRs:
-            avg: AVG(accum_vgpr)
-            min: MIN(accum_vgpr)
-            max: MAX(accum_vgpr)
+            avg: AVG(Accum_VGPR)
+            min: MIN(Accum_VGPR)
+            max: MAX(Accum_VGPR)
             unit: Registers
-            tips: 
+            tips:
           SGPRs:
-            avg: AVG(sgpr)
-            min: MIN(sgpr)
-            max: MAX(sgpr)
+            avg: AVG(SGPR)
+            min: MIN(SGPR)
+            max: MAX(SGPR)
             unit: Registers
-            tips: 
+            tips:
           LDS Allocation:
-            avg: AVG(lds)
-            min: MIN(lds)
-            max: MAX(lds)
+            avg: AVG(LDS_Per_Workgroup)
+            min: MIN(LDS_Per_Workgroup)
+            max: MAX(LDS_Per_Workgroup)
             unit: Bytes
-            tips: 
+            tips:
           Scratch Allocation:
-            avg: AVG(scr)
-            min: MIN(scr)
-            max: MAX(scr)
+            avg: AVG(Scratch_Per_Workitem)
+            min: MIN(Scratch_Per_Workitem)
+            max: MAX(Scratch_Per_Workitem)
             unit: Bytes
-            tips: 
+            tips:
 
     - metric_table:
         id: 702
@@ -96,47 +96,47 @@ Panel Config:
             min: MIN((EndNs - BeginNs))
             max: MAX((EndNs - BeginNs))
             unit: ns
-            tips: 
+            tips:
           Kernel Time (Cycles):
             avg: AVG(GRBM_GUI_ACTIVE)
             min: MIN(GRBM_GUI_ACTIVE)
             max: MAX(GRBM_GUI_ACTIVE)
             unit: Cycle
-            tips: 
+            tips:
           Instr/wavefront:
             avg: AVG((SQ_INSTS / SQ_WAVES))
             min: MIN((SQ_INSTS / SQ_WAVES))
             max: MAX((SQ_INSTS / SQ_WAVES))
             unit: Instr/wavefront
-            tips: 
+            tips:
           Wave Cycles:
             avg: AVG(((4 * SQ_WAVE_CYCLES) / $denom))
             min: MIN(((4 * SQ_WAVE_CYCLES) / $denom))
             max: MAX(((4 * SQ_WAVE_CYCLES) / $denom))
             unit: (Cycles + $normUnit)
-            tips: 
+            tips:
           Dependency Wait Cycles:
             avg: AVG(((4 * SQ_WAIT_ANY) / $denom))
             min: MIN(((4 * SQ_WAIT_ANY) / $denom))
             max: MAX(((4 * SQ_WAIT_ANY) / $denom))
             unit: (Cycles + $normUnit)
-            tips: 
+            tips:
           Issue Wait Cycles:
             avg: AVG(((4 * SQ_WAIT_INST_ANY) / $denom))
             min: MIN(((4 * SQ_WAIT_INST_ANY) / $denom))
             max: MAX(((4 * SQ_WAIT_INST_ANY) / $denom))
             unit: (Cycles + $normUnit)
-            tips: 
+            tips:
           Active Cycles:
             avg: AVG(((4 * SQ_ACTIVE_INST_ANY) / $denom))
             min: MIN(((4 * SQ_ACTIVE_INST_ANY) / $denom))
             max: MAX(((4 * SQ_ACTIVE_INST_ANY) / $denom))
             unit: (Cycles + $normUnit)
-            tips: 
+            tips:
           Wavefront Occupancy:
             avg: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
             min: MIN((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
             max: MAX((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
             unit: Wavefronts
             coll_level: SQ_LEVEL_WAVES
-            tips:  
+            tips:

--- a/src/omniperf_analyze/configs/gfx941/1200_lds.yaml
+++ b/src/omniperf_analyze/configs/gfx941/1200_lds.yaml
@@ -22,14 +22,18 @@ Panel Config:
           Access Rate:
             value: AVG(((200 * SQ_ACTIVE_INST_LDS) / (GRBM_GUI_ACTIVE * $numCU)))
             tips:
-          Bandwith (Pct-of-Peak):
-            value: AVG((((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
+          Bandwidth (Pct-of-Peak):
+            value:
+              AVG((((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
               / (EndNs - BeginNs)) / (($sclk * $numCU) * 0.00128)))
             tips:
           Bank Conflict Rate:
-            value: AVG((((SQ_LDS_BANK_CONFLICT * 3.125) / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
+            value:
+              AVG((((SQ_LDS_BANK_CONFLICT * 3.125) / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
               if ((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) != 0) else None))
             tips:
+        comparable: false # for now
+        cli_style: simple_bar
 
     - metric_table:
         id: 1202
@@ -49,20 +53,26 @@ Panel Config:
             unit: (Instr  + $normUnit)
             tips:
           Bandwidth:
-            avg: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
+            avg:
+              AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
               / $denom))
-            min: MIN(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
+            min:
+              MIN(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
               / $denom))
-            max: MAX(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
+            max:
+              MAX(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($LDSBanks))
               / $denom))
             unit: (Bytes  + $normUnit)
             tips:
           Bank Conficts/Access:
-            avg: AVG(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
+            avg:
+              AVG(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
               if ((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) != 0) else None))
-            min: MIN(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
+            min:
+              MIN(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
               if ((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) != 0) else None))
-            max: MAX(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
+            max:
+              MAX(((SQ_LDS_BANK_CONFLICT / (SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT))
               if ((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) != 0) else None))
             unit: Conflicts/Access
             tips:
@@ -71,37 +81,37 @@ Panel Config:
             min: MIN((SQ_LDS_IDX_ACTIVE / $denom))
             max: MAX((SQ_LDS_IDX_ACTIVE / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Atomic Cycles:
             avg: AVG((SQ_LDS_ATOMIC_RETURN / $denom))
             min: MIN((SQ_LDS_ATOMIC_RETURN / $denom))
             max: MAX((SQ_LDS_ATOMIC_RETURN / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Bank Conflict:
             avg: AVG((SQ_LDS_BANK_CONFLICT / $denom))
             min: MIN((SQ_LDS_BANK_CONFLICT / $denom))
             max: MAX((SQ_LDS_BANK_CONFLICT / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Addr Conflict:
             avg: AVG((SQ_LDS_ADDR_CONFLICT / $denom))
             min: MIN((SQ_LDS_ADDR_CONFLICT / $denom))
             max: MAX((SQ_LDS_ADDR_CONFLICT / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Unaligned Stall:
             avg: AVG((SQ_LDS_UNALIGNED_STALL / $denom))
             min: MIN((SQ_LDS_UNALIGNED_STALL / $denom))
             max: MAX((SQ_LDS_UNALIGNED_STALL / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:
           Mem Violations:
             avg: AVG((SQ_LDS_MEM_VIOLATIONS / $denom))
             min: MIN((SQ_LDS_MEM_VIOLATIONS / $denom))
             max: MAX((SQ_LDS_MEM_VIOLATIONS / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           LDS Latency:
             avg: AVG(((SQ_ACCUM_PREV_HIRES / SQ_INSTS_LDS) if (SQ_INSTS_LDS != 0) else None))
             min: MIN(((SQ_ACCUM_PREV_HIRES / SQ_INSTS_LDS) if (SQ_INSTS_LDS != 0) else None))

--- a/src/omniperf_analyze/configs/gfx941/1300_instruction-cache.yaml
+++ b/src/omniperf_analyze/configs/gfx941/1300_instruction-cache.yaml
@@ -19,11 +19,14 @@ Panel Config:
           Bandwidth:
             value: AVG(((SQC_ICACHE_REQ * 100000) / (($sclk * $numSQC)
               * (EndNs - BeginNs))))
-            tips: 
+            tips:
           Cache Hit:
-            value: AVG(((SQC_ICACHE_HITS * 100) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
+            value:
+              AVG(((SQC_ICACHE_HITS * 100) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
               + SQC_ICACHE_MISSES_DUPLICATE)))
-            tips: 
+            tips:
+        comparable: false # for now
+        cli_style: simple_bar
 
     - metric_table:
         id: 1302
@@ -37,35 +40,38 @@ Panel Config:
           tips: Tips
         metric:
           Req:
-            Avg: AVG((SQC_ICACHE_REQ / $denom))
+            avg: AVG((SQC_ICACHE_REQ / $denom))
             min: MIN((SQC_ICACHE_REQ / $denom))
             max: MAX((SQC_ICACHE_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Hits:
-            Avg: AVG((SQC_ICACHE_HITS / $denom))
+            avg: AVG((SQC_ICACHE_HITS / $denom))
             min: MIN((SQC_ICACHE_HITS / $denom))
             max: MAX((SQC_ICACHE_HITS / $denom))
             unit: (Hits  + $normUnit)
-            tips: 
+            tips:
           Misses - Non Duplicated:
-            Avg: AVG((SQC_ICACHE_MISSES / $denom))
+            avg: AVG((SQC_ICACHE_MISSES / $denom))
             min: MIN((SQC_ICACHE_MISSES / $denom))
             max: MAX((SQC_ICACHE_MISSES / $denom))
             unit: (Misses  + $normUnit)
-            tips: 
+            tips:
           Misses - Duplicated:
-            Avg: AVG((SQC_ICACHE_MISSES_DUPLICATE / $denom))
+            avg: AVG((SQC_ICACHE_MISSES_DUPLICATE / $denom))
             min: MIN((SQC_ICACHE_MISSES_DUPLICATE / $denom))
             max: MAX((SQC_ICACHE_MISSES_DUPLICATE / $denom))
             unit: (Misses  + $normUnit)
-            tips: 
+            tips:
           Cache Hit:
-            Avg: AVG(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
+            avg:
+              AVG(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
               + SQC_ICACHE_MISSES_DUPLICATE)))
-            min: MIN(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES) +
+            min:
+              MIN(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES) +
               SQC_ICACHE_MISSES_DUPLICATE)))
-            max: MAX(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES) +
+            max:
+              MAX(((100 * SQC_ICACHE_HITS) / ((SQC_ICACHE_HITS + SQC_ICACHE_MISSES) +
               SQC_ICACHE_MISSES_DUPLICATE)))
             unit: pct
-            tips: 
+            tips:

--- a/src/omniperf_analyze/configs/gfx941/1400_constant-cache.yaml
+++ b/src/omniperf_analyze/configs/gfx941/1400_constant-cache.yaml
@@ -25,6 +25,8 @@ Panel Config:
               AVG((((SQC_DCACHE_HITS * 100) / (SQC_DCACHE_HITS + SQC_DCACHE_MISSES + SQC_DCACHE_MISSES_DUPLICATE))
               if ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES + SQC_DCACHE_MISSES_DUPLICATE) != 0) else None))
             tips:
+        comparable: false # for now
+        cli_style: simple_bar
 
     - metric_table:
         id: 1402
@@ -42,76 +44,82 @@ Panel Config:
             min: MIN((SQC_DCACHE_REQ / $denom))
             max: MAX((SQC_DCACHE_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Hits:
             avg: AVG((SQC_DCACHE_HITS / $denom))
             min: MIN((SQC_DCACHE_HITS / $denom))
             max: MAX((SQC_DCACHE_HITS / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Misses - Non Duplicated:
             avg: AVG((SQC_DCACHE_MISSES / $denom))
             min: MIN((SQC_DCACHE_MISSES / $denom))
             max: MAX((SQC_DCACHE_MISSES / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Misses- Duplicated:
             avg: AVG((SQC_DCACHE_MISSES_DUPLICATE / $denom))
             min: MIN((SQC_DCACHE_MISSES_DUPLICATE / $denom))
             max: MAX((SQC_DCACHE_MISSES_DUPLICATE / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Cache Hit:
-            avg: AVG((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
+            avg:
+              AVG((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE)) if (((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE) != 0) else None))
-            min: MIN((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
+            min:
+              MIN((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE)) if (((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE) != 0) else None))
-            max: MAX((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
+            max:
+              MAX((((100 * SQC_DCACHE_HITS) / ((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE)) if (((SQC_DCACHE_HITS + SQC_DCACHE_MISSES)
               + SQC_DCACHE_MISSES_DUPLICATE) != 0) else None))
             unit: pct
-            tips: 
+            tips:
           Read Req (Total):
-            avg: AVG((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
+            avg:
+              AVG((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
               + SQC_DCACHE_REQ_READ_8) + SQC_DCACHE_REQ_READ_16) / $denom))
-            min: MIN((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
+            min:
+              MIN((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
               + SQC_DCACHE_REQ_READ_8) + SQC_DCACHE_REQ_READ_16) / $denom))
-            max: MAX((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
+            max:
+              MAX((((((SQC_DCACHE_REQ_READ_1 + SQC_DCACHE_REQ_READ_2) + SQC_DCACHE_REQ_READ_4)
               + SQC_DCACHE_REQ_READ_8) + SQC_DCACHE_REQ_READ_16) / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Atomic Req:
             avg: AVG((SQC_DCACHE_ATOMIC / $denom))
             min: MIN((SQC_DCACHE_ATOMIC / $denom))
             max: MAX((SQC_DCACHE_ATOMIC / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (1 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_1 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_1 / $denom))
             max: MAX((SQC_DCACHE_REQ_READ_1 / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (2 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_2 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_2 / $denom))
             max: MAX((SQC_DCACHE_REQ_READ_2 / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (4 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_4 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_4 / $denom))
             max: MAX((SQC_DCACHE_REQ_READ_4 / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (8 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_8 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_8 / $denom))
             max: MAX((SQC_DCACHE_REQ_READ_8 / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req (16 DWord):
             avg: AVG((SQC_DCACHE_REQ_READ_16 / $denom))
             min: MIN((SQC_DCACHE_REQ_READ_16 / $denom))
@@ -135,22 +143,22 @@ Panel Config:
             min: MIN((SQC_TC_DATA_READ_REQ / $denom))
             max: MAX((SQC_TC_DATA_READ_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write Req:
             avg: AVG((SQC_TC_DATA_WRITE_REQ / $denom))
             min: MIN((SQC_TC_DATA_WRITE_REQ / $denom))
             max: MAX((SQC_TC_DATA_WRITE_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Atomic Req:
             avg: AVG((SQC_TC_DATA_ATOMIC_REQ / $denom))
             min: MIN((SQC_TC_DATA_ATOMIC_REQ / $denom))
             max: MAX((SQC_TC_DATA_ATOMIC_REQ / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Stall:
             avg: AVG((SQC_TC_STALL / $denom))
             min: MIN((SQC_TC_STALL / $denom))
             max: MAX((SQC_TC_STALL / $denom))
             unit: (Cycles  + $normUnit)
-            tips: 
+            tips:

--- a/src/omniperf_analyze/configs/gfx941/1600_L1_cache.yaml
+++ b/src/omniperf_analyze/configs/gfx941/1600_L1_cache.yaml
@@ -17,80 +17,64 @@ Panel Config:
           tips: Tips
         metric:
           Buffer Coalescing:
-            value: AVG(((((TA_TOTAL_WAVEFRONTS_sum * 64) * 100) / (TCP_TOTAL_ACCESSES_sum
+            value:
+              AVG(((((TA_TOTAL_WAVEFRONTS_sum * 64) * 100) / (TCP_TOTAL_ACCESSES_sum
               * 4)) if (TCP_TOTAL_ACCESSES_sum != 0) else None))
-            tips: 
+            tips:
           Cache Util:
-            value: AVG((((TCP_GATE_EN2_sum * 100) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
+            value:
+              AVG((((TCP_GATE_EN2_sum * 100) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
               != 0) else None))
-            tips: 
+            tips:
           Cache BW:
-            value: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (EndNs - BeginNs))))
+            value:
+              ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (EndNs - BeginNs))))
               / ((($sclk / 1000) * 64) * $numCU))
-            tips: 
+            tips:
           Cache Hit:
-            value: AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            value:
+              AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
-               None))
-            tips: 
+              None))
+            tips:
+        comparable: false # for now
+        cli_style: simple_bar
 
     - metric_table:
         id: 1602
-        title: L1D Cache Stalls
+        title: L1D Cache Stalls (%)
         header:
           metric: Metric
-          mean: Mean
-          min: Min
-          max: Max
-          unit: unit
+          expr: Expression
           tips: Tips
         metric:
           Stalled on L2 Data:
-            mean: AVG((((100 * TCP_PENDING_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            min: MIN((((100 * TCP_PENDING_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            max: MAX((((100 * TCP_PENDING_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_PENDING_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
+              != 0) else None)
+            tips:
           Stalled on L2 Req:
-            mean: AVG((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            min: MIN((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            max: MAX((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-              != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
+              != 0) else None)
+            tips:
           Tag RAM Stall (Read):
-            mean: AVG((((100 * TCP_READ_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            min: MIN((((100 * TCP_READ_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            max: MAX((((100 * TCP_READ_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_READ_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
+              if (TCP_GATE_EN1_sum != 0) else None)
+            tips:
           Tag RAM Stall (Write):
-            mean: AVG((((100 * TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            min: MIN((((100 * TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            max: MAX((((100 * TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
+              if (TCP_GATE_EN1_sum != 0) else None)
+            tips:
           Tag RAM Stall (Atomic):
-            mean: AVG((((100 * TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            min: MIN((((100 * TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            max: MAX((((100 * TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
-              if (TCP_GATE_EN1_sum != 0) else None))
-            unit: pct
-            tips: 
+            expr:
+              (((100 * TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
+              if (TCP_GATE_EN1_sum != 0) else None)
+            tips:
+        cli_style: simple_box
 
     - metric_table:
         id: 1603
@@ -108,25 +92,28 @@ Panel Config:
             min: MIN((TCP_TOTAL_ACCESSES_sum / $denom))
             max: MAX((TCP_TOTAL_ACCESSES_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req:
             avg: AVG((TCP_TOTAL_READ_sum / $denom))
             min: MIN((TCP_TOTAL_READ_sum / $denom))
             max: MAX((TCP_TOTAL_READ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write Req:
             avg: AVG((TCP_TOTAL_WRITE_sum / $denom))
             min: MIN((TCP_TOTAL_WRITE_sum / $denom))
             max: MAX((TCP_TOTAL_WRITE_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Atomic Req:
-            avg: AVG(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
+            avg:
+              AVG(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
               / $denom))
-            min: MIN(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
+            min:
+              MIN(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
               / $denom))
-            max: MAX(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
+            max:
+              MAX(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
               / $denom))
             unit: (Req  + $normUnit)
             tips:
@@ -141,44 +128,56 @@ Panel Config:
             min: MIN((TCP_TOTAL_CACHE_ACCESSES_sum / $denom))
             max: MAX((TCP_TOTAL_CACHE_ACCESSES_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Cache Hits:
-            avg: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            avg:
+              AVG(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / $denom))
-            min: MIN(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            min:
+              MIN(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / $denom))
-            max: MAX(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            max:
+              MAX(((TCP_TOTAL_CACHE_ACCESSES_sum - (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Cache Hit Rate:
-            avg: AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
+            avg:
+              AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
               TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) /
               TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
-               None))
-            min: MIN(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
+              None))
+            min:
+              MIN(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
               TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) /
               TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
-               None))
-            max: MAX(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
+              None))
+            max:
+              MAX(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) +
               TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) /
               TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
-               None))
+              None))
             unit: pct
-            tips: 
+            tips:
           Invalidate:
             avg: AVG((TCP_TOTAL_WRITEBACK_INVALIDATES_sum / $denom))
             min: MIN((TCP_TOTAL_WRITEBACK_INVALIDATES_sum / $denom))
             max: MAX((TCP_TOTAL_WRITEBACK_INVALIDATES_sum / $denom))
             unit: (Req + $normUnit)
-            tips: 
+            tips:
           L1-L2 BW:
-            avg: AVG(((64 * (TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            min: MIN(((64 * (TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            max: MAX(((64 * (TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            avg:
+              AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
+              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            min:
+              AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
+              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            max:
+              AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
+              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
           L1-L2 Read:
@@ -186,52 +185,64 @@ Panel Config:
             min: MIN((TCP_TCC_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           L1-L2 Write:
             avg: AVG((TCP_TCC_WRITE_REQ_sum / $denom))
             min: MIN((TCP_TCC_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           L1-L2 Atomic:
-            avg: AVG(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            avg:
+              AVG(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
-            min: MIN(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            min:
+              MIN(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
-            max: MAX(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            max:
+              MAX(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           L1 Access Latency:
-            avg: AVG(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
-              != 0) else None))
-            min: MIN(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
-              != 0) else None))
-            max: MAX(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
-              != 0) else None))
+            avg:
+              # AVG(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
+              # != 0) else None))
+            min:
+              # MIN(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
+              # != 0) else None))
+            max:
+              # MAX(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
+              # != 0) else None))
             unit: Cycles
-            tips: 
+            tips:
           L1-L2 Read Latency:
-            avg: AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
-            min: MIN(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
-            max: MAX(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
+            avg:
+              # AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
+            min:
+              # MIN(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
+            max:
+              # MAX(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None))
             unit: Cycles
-            tips: 
+            tips:
           L1-L2 Write Latency:
-            avg: AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
-              if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
-              None))
-            min: MIN(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
-              if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
-              None))
-            max: MAX(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
-              if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
-              None))
+            avg:
+              # AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
+              # if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
+              # None))
+            min:
+              # MIN(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
+              # if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
+              # None))
+            max:
+              # MAX(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
+              # if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum) != 0) else
+              # None))
             unit: Cycles
-            tips: 
+            tips:
 
     - metric_table:
         id: 1604
@@ -253,7 +264,7 @@ Panel Config:
             min: MIN((TCP_TCC_NC_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_NC_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           UC - Read:
             xfer: Read
             coherency: UC
@@ -261,7 +272,7 @@ Panel Config:
             min: MIN((TCP_TCC_UC_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_UC_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           CC - Read:
             xfer: Read
             coherency: CC
@@ -269,7 +280,7 @@ Panel Config:
             min: MIN((TCP_TCC_CC_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_CC_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           RW - Read:
             xfer: Read
             coherency: RW
@@ -277,7 +288,7 @@ Panel Config:
             min: MIN((TCP_TCC_RW_READ_REQ_sum / $denom))
             max: MAX((TCP_TCC_RW_READ_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           RW - Write:
             xfer: Write
             coherency: RW
@@ -285,7 +296,7 @@ Panel Config:
             min: MIN((TCP_TCC_RW_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_RW_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           NC - Write:
             xfer: Write
             coherency: NC
@@ -293,7 +304,7 @@ Panel Config:
             min: MIN((TCP_TCC_NC_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_NC_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           UC - Write:
             xfer: Write
             coherency: UC
@@ -301,7 +312,7 @@ Panel Config:
             min: MIN((TCP_TCC_UC_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_UC_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           CC - Write:
             xfer: Write
             coherency: CC
@@ -309,7 +320,7 @@ Panel Config:
             min: MIN((TCP_TCC_CC_WRITE_REQ_sum / $denom))
             max: MAX((TCP_TCC_CC_WRITE_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           NC - Atomic:
             xfer: Atomic
             coherency: NC
@@ -317,7 +328,7 @@ Panel Config:
             min: MIN((TCP_TCC_NC_ATOMIC_REQ_sum / $denom))
             max: MAX((TCP_TCC_NC_ATOMIC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           UC - Atomic:
             xfer: Atomic
             coherency: UC
@@ -325,7 +336,7 @@ Panel Config:
             min: MIN((TCP_TCC_UC_ATOMIC_REQ_sum / $denom))
             max: MAX((TCP_TCC_UC_ATOMIC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           CC - Atomic:
             xfer: Atomic
             coherency: CC
@@ -333,7 +344,7 @@ Panel Config:
             min: MIN((TCP_TCC_CC_ATOMIC_REQ_sum / $denom))
             max: MAX((TCP_TCC_CC_ATOMIC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           RW - Atomic:
             xfer: Atomic
             coherency: RW
@@ -341,7 +352,7 @@ Panel Config:
             min: MIN((TCP_TCC_RW_ATOMIC_REQ_sum / $denom))
             max: MAX((TCP_TCC_RW_ATOMIC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
 
     - metric_table:
         id: 1605
@@ -359,31 +370,34 @@ Panel Config:
             min: MIN((TCP_UTCL1_REQUEST_sum / $denom))
             max: MAX((TCP_UTCL1_REQUEST_sum / $denom))
             units: ( + $normUnit)
-            tips: 
+            tips:
           Hit Ratio:
-            avg: AVG((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
+            avg:
+              AVG((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
               (TCP_UTCL1_REQUEST_sum != 0) else None))
-            min: MIN((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
+            min:
+              MIN((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
               (TCP_UTCL1_REQUEST_sum != 0) else None))
-            max: MAX((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
+            max:
+              MAX((((100 * TCP_UTCL1_TRANSLATION_HIT_sum) / TCP_UTCL1_REQUEST_sum) if
               (TCP_UTCL1_REQUEST_sum != 0) else None))
             units: pct
-            tips: 
+            tips:
           Hits:
             avg: AVG((TCP_UTCL1_TRANSLATION_HIT_sum / $denom))
             min: MIN((TCP_UTCL1_TRANSLATION_HIT_sum / $denom))
             max: MAX((TCP_UTCL1_TRANSLATION_HIT_sum / $denom))
             units: ( + $normUnit)
-            tips: 
+            tips:
           Misses (Translation):
             avg: AVG((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             max: MAX((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             units: ( + $normUnit)
-            tips: 
+            tips:
           Misses (Permission):
             avg: AVG((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             max: MAX((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             units: ( + $normUnit)
-            tips: 
+            tips:

--- a/src/omniperf_analyze/configs/gfx941/1700_L2_cache.yaml
+++ b/src/omniperf_analyze/configs/gfx941/1700_L2_cache.yaml
@@ -20,22 +20,25 @@ Panel Config:
           L2 Util:
             value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
             unit: pct
-            tips: 
+            tips:
           Cache Hit:
-            value: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            value:
+              AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else 0))
             unit: pct
-            tips: 
+            tips:
           L2-EA Rd BW:
-            value: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
+            value:
+              AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
               * 64)) / (EndNs - BeginNs)))
             unit: GB/s
-            tips: 
+            tips:
           L2-EA Wr BW:
-            value: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
+            value:
+              AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
               * 32)) / (EndNs - BeginNs)))
             unit: GB/s
-            tips: 
+            tips:
 
     - metric_table:
         id: 1702
@@ -49,122 +52,143 @@ Panel Config:
           tips: Tips
         metric:
           Read BW:
-            avg: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
+            avg:
+              AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
               * 64)) / $denom))
-            min: MIN((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
+            min:
+              MIN((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
               * 64)) / $denom))
-            max: MAX((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
+            max:
+              MAX((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
               * 64)) / $denom))
             unit: (Bytes  + $normUnit)
-            tips: 
+            tips:
           Write BW:
-            avg: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
+            avg:
+              AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
               * 32)) / $denom))
-            min: MIN((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
+            min:
+              MIN((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
               * 32)) / $denom))
-            max: MAX((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
+            max:
+              MAX((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
               * 32)) / $denom))
             unit: (Bytes  + $normUnit)
-            tips: 
+            tips:
           Read (32B):
             avg: AVG((TCC_EA0_RDREQ_32B_sum / $denom))
             min: MIN((TCC_EA0_RDREQ_32B_sum / $denom))
             max: MAX((TCC_EA0_RDREQ_32B_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read (Uncached 32B):
             avg: AVG((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
             min: MIN((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
             max: MAX((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read (64B):
             avg: AVG(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
             min: MIN(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
             max: MAX(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           HBM Read:
             avg: AVG((TCC_EA0_RDREQ_DRAM_sum / $denom))
             min: MIN((TCC_EA0_RDREQ_DRAM_sum / $denom))
             max: MAX((TCC_EA0_RDREQ_DRAM_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write (32B):
             avg: AVG(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             min: MIN(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             max: MAX(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write (Uncached 32B):
             avg: AVG((TCC_EA0_WR_UNCACHED_32B_sum / $denom))
             min: MIN((TCC_EA0_WR_UNCACHED_32B_sum / $denom))
             max: MAX((TCC_EA0_WR_UNCACHED_32B_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write (64B):
             avg: AVG((TCC_EA0_WRREQ_64B_sum / $denom))
             min: MIN((TCC_EA0_WRREQ_64B_sum / $denom))
             max: MAX((TCC_EA0_WRREQ_64B_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           HBM Write:
             avg: AVG((TCC_EA0_WRREQ_DRAM_sum / $denom))
             min: MIN((TCC_EA0_WRREQ_DRAM_sum / $denom))
             max: MAX((TCC_EA0_WRREQ_DRAM_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Latency:
-            avg: AVG(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
+            avg:
+              AVG(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
               0) else None))
-            min: MIN(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
+            min:
+              MIN(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
               0) else None))
-            max: MAX(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
+            max:
+              MAX(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum !=
               0) else None))
             unit: Cycles
-            tips: 
+            tips:
           Write Latency:
-            avg: AVG(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
+            avg:
+              AVG(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
               0) else None))
-            min: MIN(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
+            min:
+              MIN(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
               0) else None))
-            max: MAX(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
+            max:
+              MAX(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum !=
               0) else None))
             unit: Cycles
-            tips: 
+            tips:
           Atomic Latency:
-            avg: AVG(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
+            avg:
+              AVG(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
               != 0) else None))
-            min: MIN(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
+            min:
+              MIN(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
               != 0) else None))
-            max: MAX(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
+            max:
+              MAX(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
               != 0) else None))
             unit: Cycles
-            tips: 
+            tips:
           Read Stall:
-            avg: AVG((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
-            min: MIN((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
-            max: MAX((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
+            avg:
+              # AVG((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
+            min:
+              # MIN((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
+            max:
+              # MAX((((100 * ((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum + TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
             unit: pct
-            tips: 
+            tips:
           Write Stall:
-            avg: AVG((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
-            min: MIN((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
-            max: MAX((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
-              + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
-              0) else None))
+            avg:
+              # AVG((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
+            min:
+              # MIN((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
+            max:
+              # MAX((((100 * ((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum + TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum)
+              # + TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum)) / TCC_BUSY_sum) if (TCC_BUSY_sum !=
+              # 0) else None))
             unit: pct
-            tips: 
+            tips:
 
     - metric_table:
         id: 1703
@@ -182,112 +206,115 @@ Panel Config:
             min: MIN((TCC_REQ_sum / $denom))
             max: MAX((TCC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Streaming Req:
             avg: AVG((TCC_STREAMING_REQ_sum / $denom))
             min: MIN((TCC_STREAMING_REQ_sum / $denom))
             max: MAX((TCC_STREAMING_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read Req:
             avg: AVG((TCC_READ_sum / $denom))
             min: MIN((TCC_READ_sum / $denom))
             max: MAX((TCC_READ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write Req:
             avg: AVG((TCC_WRITE_sum / $denom))
             min: MIN((TCC_WRITE_sum / $denom))
             max: MAX((TCC_WRITE_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Atomic Req:
             avg: AVG((TCC_ATOMIC_sum / $denom))
             min: MIN((TCC_ATOMIC_sum / $denom))
             max: MAX((TCC_ATOMIC_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Probe Req:
             avg: AVG((TCC_PROBE_sum / $denom))
             min: MIN((TCC_PROBE_sum / $denom))
             max: MAX((TCC_PROBE_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Hits:
             avg: AVG((TCC_HIT_sum / $denom))
             min: MIN((TCC_HIT_sum / $denom))
             max: MAX((TCC_HIT_sum / $denom))
             unit: (Hits  + $normUnit)
-            tips: 
+            tips:
           Misses:
             avg: AVG((TCC_MISS_sum / $denom))
             min: MIN((TCC_MISS_sum / $denom))
             max: MAX((TCC_MISS_sum / $denom))
             unit: (Misses  + $normUnit)
-            tips: 
+            tips:
           Cache Hit:
-            avg: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            avg:
+              AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else None))
-            min: MIN((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            min:
+              MIN((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else None))
-            max: MAX((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            max:
+              MAX((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else None))
             unit: pct
-            tips: 
+            tips:
           Writeback:
             avg: AVG((TCC_WRITEBACK_sum / $denom))
             min: MIN((TCC_WRITEBACK_sum / $denom))
             max: MAX((TCC_WRITEBACK_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           NC Req:
             avg: AVG((TCC_NC_REQ_sum / $denom))
             min: MIN((TCC_NC_REQ_sum / $denom))
             max: MAX((TCC_NC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           UC Req:
             avg: AVG((TCC_UC_REQ_sum / $denom))
             min: MIN((TCC_UC_REQ_sum / $denom))
             max: MAX((TCC_UC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           CC Req:
             avg: AVG((TCC_CC_REQ_sum / $denom))
             min: MIN((TCC_CC_REQ_sum / $denom))
             max: MAX((TCC_CC_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           RW Req:
             avg: AVG((TCC_RW_REQ_sum / $denom))
             min: MIN((TCC_RW_REQ_sum / $denom))
             max: MAX((TCC_RW_REQ_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Writeback (Normal):
             avg: AVG((TCC_NORMAL_WRITEBACK_sum / $denom))
             min: MIN((TCC_NORMAL_WRITEBACK_sum / $denom))
             max: MAX((TCC_NORMAL_WRITEBACK_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           Writeback (TC Req):
             avg: AVG((TCC_ALL_TC_OP_WB_WRITEBACK_sum / $denom))
             min: MIN((TCC_ALL_TC_OP_WB_WRITEBACK_sum / $denom))
             max: MAX((TCC_ALL_TC_OP_WB_WRITEBACK_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           Evict (Normal):
             avg: AVG((TCC_NORMAL_EVICT_sum / $denom))
             min: MIN((TCC_NORMAL_EVICT_sum / $denom))
             max: MAX((TCC_NORMAL_EVICT_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
           Evict (TC Req):
             avg: AVG((TCC_ALL_TC_OP_INV_EVICT_sum / $denom))
             min: MIN((TCC_ALL_TC_OP_INV_EVICT_sum / $denom))
             max: MAX((TCC_ALL_TC_OP_INV_EVICT_sum / $denom))
             unit: ( + $normUnit)
-            tips: 
+            tips:
 
     - metric_table:
         id: 1704
@@ -305,51 +332,51 @@ Panel Config:
           Read - Remote Socket Stall:
             type: Remote Socket Stall
             transaction: Read
-            avg: AVG((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_RDREQ_IO_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read - Peer GCD Stall:
             type: Peer GCD Stall
             transaction: Read
-            avg: AVG((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Read - HBM Stall:
             type: HBM Stall
             transaction: Read
-            avg: AVG((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write - Remote Socket Stall:
             type: Remote Socket Stall
             transaction: Write
-            avg: AVG((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_WRREQ_IO_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write - Peer GCD Stall:
             type: Peer GCD Stall
             transaction: Write
-            avg: AVG((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write - HBM Stall:
             type: HBM Stall
             transaction: Write
-            avg: AVG((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
-            min: MIN((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
-            max: MAX((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
+            avg: # AVG((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
+            min: # MIN((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
+            max: # MAX((TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:
           Write - Credit Starvation:
             type: Credit Starvation
             transaction: Write
@@ -357,4 +384,4 @@ Panel Config:
             min: MIN((TCC_TOO_MANY_EA_WRREQS_STALL_sum / $denom))
             max: MAX((TCC_TOO_MANY_EA_WRREQS_STALL_sum / $denom))
             unit: (Req  + $normUnit)
-            tips: 
+            tips:

--- a/src/omniperf_analyze/configs/gfx941/1800_L2_cache_per_channel.yaml
+++ b/src/omniperf_analyze/configs/gfx941/1800_L2_cache_per_channel.yaml
@@ -117,7 +117,7 @@ Panel Config:
               (((100 * TCC_HIT[::_1]) / (TCC_HIT[::_1] + TCC_MISS[::_1])) if ((TCC_HIT[::_1]
               + TCC_MISS[::_1]) != 0) else None)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -130,7 +130,7 @@ Panel Config:
           "::_1":
             expr: (TO_INT(TCC_REQ[::_1]) / $denom)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -147,7 +147,7 @@ Panel Config:
             write req: AVG((TO_INT(TCC_WRITE[::_1]) / $denom))
             atomic req: AVG((TO_INT(TCC_ATOMIC[::_1]) / $denom))
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_multiple_bar
 
     - metric_table:
@@ -160,11 +160,11 @@ Panel Config:
           atomic req: L2-EA Atomic
         metric:
           "::_1":
-            read req: AVG((TO_INT(TCC_EA_RDREQ[::_1]) / $denom))
-            write req: AVG((TO_INT(TCC_EA_WRREQ[::_1]) / $denom))
-            atomic req: AVG((TO_INT(TCC_EA_ATOMIC[::_1]) / $denom))
+            read req: AVG((TO_INT(TCC_EA0_RDREQ[::_1]) / $denom))
+            write req: AVG((TO_INT(TCC_EA0_WRREQ[::_1]) / $denom))
+            atomic req: AVG((TO_INT(TCC_EA0_ATOMIC[::_1]) / $denom))
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_multiple_bar
 
     # - metric_table:
@@ -178,16 +178,16 @@ Panel Config:
     #     metric:
     #       "::_1":
     #         read lat:
-    #           AVG(((TCC_EA_RDREQ_LEVEL[::_1] / TCC_EA_RDREQ[::_1]) if (TCC_EA_RDREQ[::_1]
+    #           AVG(((TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]) if (TCC_EA0_RDREQ[::_1]
     #           != 0) else None))
     #         write lat:
-    #           AVG(((TCC_EA_WRREQ_LEVEL[::_1] / TCC_EA_WRREQ[::_1]) if (TCC_EA_WRREQ[::_1]
+    #           AVG(((TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]) if (TCC_EA0_WRREQ[::_1]
     #           != 0) else None))
     #         atomic lat:
-    #           AVG(((TCC_EA_ATOMIC_LEVEL[::_1] / TCC_EA_ATOMIC[::_1]) if
-    #           (TCC_EA_ATOMIC[::_1] != 0) else 0))
+    #           AVG(((TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1]) if
+    #           (TCC_EA0_ATOMIC[::_1] != 0) else 0))
     #       placeholder_range:
-    #         "::_1": 96
+    #         "::_1": $totalL2Banks
     #     cli_style: simple_multiple_bar
 
     - metric_table:
@@ -199,10 +199,10 @@ Panel Config:
         metric:
           "::_1":
             expr:
-              ((TCC_EA_RDREQ_LEVEL[::_1] / TCC_EA_RDREQ[::_1]) if (TCC_EA_RDREQ[::_1]
+              ((TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]) if (TCC_EA0_RDREQ[::_1]
               != 0) else None)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -214,10 +214,10 @@ Panel Config:
         metric:
           "::_1":
             expr:
-              ((TCC_EA_WRREQ_LEVEL[::_1] / TCC_EA_WRREQ[::_1]) if (TCC_EA_WRREQ[::_1]
+              ((TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]) if (TCC_EA0_WRREQ[::_1]
               != 0) else None)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -228,10 +228,10 @@ Panel Config:
           expr: Expression
         metric:
           "::_1":
-            expr: ((TCC_EA_ATOMIC_LEVEL[::_1] / TCC_EA_ATOMIC[::_1]) if
-              (TCC_EA_ATOMIC[::_1] != 0) else 0)
+            expr: ((TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1]) if
+              (TCC_EA0_ATOMIC[::_1] != 0) else 0)
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_box
 
     - metric_table:
@@ -244,11 +244,11 @@ Panel Config:
           ea read stall - dram: L2-EA Read Stall - DRAM
         metric:
           "::_1":
-            ea read stall - io: AVG((TO_INT(TCC_EA_RDREQ_IO_CREDIT_STALL[::_1]) / $denom))
-            ea read stall - gmi: AVG((TO_INT(TCC_EA_RDREQ_GMI_CREDIT_STALL[::_1]) / $denom))
-            ea read stall - dram: AVG((TO_INT(TCC_EA_RDREQ_DRAM_CREDIT_STALL[::_1]) / $denom))
+            ea read stall - io: AVG((TO_INT(TCC_EA0_RDREQ_IO_CREDIT_STALL[::_1]) / $denom))
+            ea read stall - gmi: AVG((TO_INT(TCC_EA0_RDREQ_GMI_CREDIT_STALL[::_1]) / $denom))
+            ea read stall - dram: AVG((TO_INT(TCC_EA0_RDREQ_DRAM_CREDIT_STALL[::_1]) / $denom))
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_multiple_bar
 
     - metric_table:
@@ -262,10 +262,37 @@ Panel Config:
           ea write stall - starve: L2-EA Write Stall - Starve
         metric:
           "::_1":
-            ea write stall - io: AVG((TO_INT(TCC_EA_WRREQ_IO_CREDIT_STALL[::_1]) / $denom))
-            ea write stall - gmi: AVG((TO_INT(TCC_EA_WRREQ_GMI_CREDIT_STALL[::_1]) / $denom))
-            ea write stall - dram: AVG((TO_INT(TCC_EA_WRREQ_DRAM_CREDIT_STALL[::_1]) / $denom))
-            ea write stall - starve: AVG((TO_INT(TCC_TOO_MANY_EA_WRREQS_STALL[::_1]) / $denom))
+            ea write stall - io: AVG((TO_INT(TCC_EA0_WRREQ_IO_CREDIT_STALL[::_1]) / $denom))
+            ea write stall - gmi: AVG((TO_INT(TCC_EA0_WRREQ_GMI_CREDIT_STALL[::_1]) / $denom))
+            ea write stall - dram: AVG((TO_INT(TCC_EA0_WRREQ_DRAM_CREDIT_STALL[::_1]) / $denom))
+            ea write stall - starve: AVG((TO_INT(TCC_TOO_MANY_EA0_WRREQS_STALL[::_1]) / $denom))
           placeholder_range:
-            "::_1": 96
+            "::_1": $totalL2Banks
         cli_style: simple_multiple_bar
+
+    - metric_table:
+        id: 1811
+        title: L2 Tag Stall (cycles)
+        header:
+          metric: Metric
+          expr: Expression
+        metric:
+          "::_1":
+            expr: TCC_TAG_STALL[::_1]
+          placeholder_range:
+            "::_1": $totalL2Banks
+        cli_style: simple_box
+
+    - metric_table:
+        id: 1812
+        title: L2 Bubble (128B request)
+        header:
+          metric: Metric
+          expr: Expression
+        metric:
+          "::_1":
+            expr: TCC_BUBBLE[::_1]
+          placeholder_range:
+            "::_1": $totalL2Banks
+          # tips: Number of 128-byte read requests sent to EA
+        cli_style: simple_box

--- a/src/omniperf_analyze/configs/gfx941/1900_memory_chart.yaml
+++ b/src/omniperf_analyze/configs/gfx941/1900_memory_chart.yaml
@@ -18,241 +18,256 @@ Panel Config:
           tips: Tips
         metric:
           Wave Life:
-            value: ROUND(AVG(((4 * (SQ_WAVE_CYCLES / SQ_WAVES)) if (SQ_WAVES != 0) else
+            value:
+              ROUND(AVG(((4 * (SQ_WAVE_CYCLES / SQ_WAVES)) if (SQ_WAVES != 0) else
               None)), 0)
             alias: wave_life_
-            tips: 
+            tips:
           Active CUs:
             value: CONCAT(CONCAT($numActiveCUs, "/"), $numCU)
             alias: active_cu_
-            tips: 
+            tips:
           SALU:
             value: ROUND(AVG((SQ_INSTS_SALU / $denom)), 0)
             alias: salu_
-            tips: 
+            tips:
           SMEM:
             value: ROUND(AVG((SQ_INSTS_SMEM / $denom)), 0)
             alias: smem_
-            tips: 
+            tips:
           VALU:
             value: ROUND(AVG((SQ_INSTS_VALU / $denom)), 0)
             alias: valu_
-            tips: 
+            tips:
           MFMA:
             value: ROUND(AVG((SQ_INSTS_MFMA / $denom)), 0)
             alias: mfma_
-            tips: 
+            tips:
           VMEM:
             value: ROUND(AVG((SQ_INSTS_VMEM / $denom)), 0)
             alias: vmem_
-            tips: 
+            tips:
           LDS:
             value: ROUND(AVG((SQ_INSTS_LDS / $denom)), 0)
             alias: lds_
-            tips: 
+            tips:
           GWS:
             value: ROUND(AVG((SQ_INSTS_GDS / $denom)), 0)
             alias: gws_
-            tips: 
+            tips:
           BR:
             value: ROUND(AVG((SQ_INSTS_BRANCH / $denom)), 0)
             alias: br_
-            tips: 
+            tips:
           VGPR:
             value: ROUND(AVG(vgpr), 0)
             alias: vgpr_
-            tips: 
+            tips:
           SGPR:
             value: ROUND(AVG(sgpr), 0)
             alias: sgpr_
-            tips: 
+            tips:
           LDS Allocation:
             value: ROUND(AVG(lds), 0)
             alias: lds_alloc_
-            tips: 
+            tips:
           Scratch Allocation:
             value: ROUND(AVG(scr), 0)
             alias: scratch_alloc_
-            tips: 
+            tips:
           Wavefronts:
             value: ROUND(AVG(SPI_CSN_WAVE), 0)
             alias: wavefronts_
-            tips: 
+            tips:
           Workgroups:
             value: ROUND(AVG(SPI_CSN_NUM_THREADGROUPS), 0)
             alias: workgroups_
-            tips: 
+            tips:
           LDS Req:
             value: ROUND(AVG((SQ_INSTS_LDS / $denom)), 0)
             alias: lds_req_
-            tips: 
+            tips:
           IL1 Fetch:
             value: ROUND(AVG((SQC_ICACHE_REQ / $denom)), 0)
             alias: il1_fetch_
-            tips: 
+            tips:
           IL1 Hit:
             value: ROUND((AVG((SQC_ICACHE_HITS / SQC_ICACHE_REQ)) * 100), 0)
             alias: il1_hit_
-            tips: 
+            tips:
           IL1_L2 Rd:
             value: ROUND(AVG((SQC_TC_INST_REQ / $denom)), 0)
             alias: il1_l2_req_
-            tips: 
+            tips:
           vL1D Rd:
             value: ROUND(AVG((SQC_DCACHE_REQ / $denom)), 0)
             alias: sl1_rd_
-            tips: 
+            tips:
           vL1D Hit:
-            value: ROUND((AVG(((SQC_DCACHE_HITS / SQC_DCACHE_REQ) if (SQC_DCACHE_REQ !=
+            value:
+              ROUND((AVG(((SQC_DCACHE_HITS / SQC_DCACHE_REQ) if (SQC_DCACHE_REQ !=
               0) else None)) * 100), 0)
             alias: sl1_hit_
-            tips: 
+            tips:
           vL1D_L2 Rd:
             value: ROUND(AVG((SQC_TC_DATA_READ_REQ / $denom)), 0)
             alias: sl1_l2_rd_
-            tips: 
+            tips:
           vL1D_L2 Wr:
             value: ROUND(AVG((SQC_TC_DATA_WRITE_REQ / $denom)), 0)
             alias: sl1_l2_wr_
-            tips: 
+            tips:
           vL1D_L2 Atomic:
             value: ROUND(AVG((SQC_TC_DATA_ATOMIC_REQ / $denom)), 0)
             alias: sl1_l2_atom_
-            tips: 
+            tips:
           VL1 Rd:
             value: ROUND(AVG((TCP_TOTAL_READ_sum / $denom)), 0)
             alias: vl1_rd_
-            tips: 
+            tips:
           VL1 Wr:
             value: ROUND(AVG((TCP_TOTAL_WRITE_sum / $denom)), 0)
             alias: vl1_wr_
-            tips: 
+            tips:
           VL1 Atomic:
-            value: ROUND(AVG(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
+            value:
+              ROUND(AVG(((TCP_TOTAL_ATOMIC_WITH_RET_sum + TCP_TOTAL_ATOMIC_WITHOUT_RET_sum)
               / $denom)), 0)
             alias: vl1_atom_
-            tips: 
+            tips:
           VL1 Hit:
-            value: ROUND(AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
+            value:
+              ROUND(AVG(((100 - ((100 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum)
               + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum))
               / TCP_TOTAL_CACHE_ACCESSES_sum)) if (TCP_TOTAL_CACHE_ACCESSES_sum != 0) else
               None)), 0)
             alias: vl1_hit_
-            tips: 
+            tips:
           VL1 Lat:
-            value: ROUND(AVG(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
-              != 0) else None)), 0)
+            value:
+              # ROUND(AVG(((TCP_TCP_LATENCY_sum / TCP_TA_TCP_STATE_READ_sum) if (TCP_TA_TCP_STATE_READ_sum
+              # != 0) else None)), 0)
             alias: vl1_lat_
-            tips: 
+            tips:
           VL1_L2 Rd:
             value: ROUND(AVG((TCP_TCC_READ_REQ_sum / $denom)), 0)
             alias: vl1_l2_rd_
-            tips: 
+            tips:
           VL1_L2 Wr:
             value: ROUND(AVG((TCP_TCC_WRITE_REQ_sum / $denom)), 0)
             alias: vl1_l2_wr_
-            tips: 
+            tips:
           vL1_L2 Atomic:
-            value: ROUND(AVG(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            value:
+              ROUND(AVG(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom)), 0)
             alias: vl1_l2_atom_
-            tips: 
+            tips:
           L2 Rd:
             value: ROUND(AVG((TCC_READ_sum / $denom)), 0)
             alias: l2_rd_
-            tips: 
+            tips:
           L2 Wr:
             value: ROUND(AVG((TCC_WRITE_sum / $denom)), 0)
             alias: l2_wr_
-            tips: 
+            tips:
           L2 Atomic:
             value: ROUND(AVG((TCC_ATOMIC_sum / $denom)), 0)
             alias: l2_atom_
-            tips: 
+            tips:
           L2 Hit:
-            value: ROUND(AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
+            value:
+              ROUND(AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
               + TCC_MISS_sum) != 0) else None)), 0)
             alias: l2_hit_
-            tips: 
+            tips:
           L2 Rd Lat:
-            value: ROUND(AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
-              if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None)),
-              0)
+            value:
+              # ROUND(AVG(((TCP_TCC_READ_REQ_LATENCY_sum / (TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum))
+              # if ((TCP_TCC_READ_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum) != 0) else None)),
+              # 0)
             alias: l2_rd_lat_
-            tips: 
+            tips:
           L2 Wr Lat:
-            value: ROUND(AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum +
-              TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
-              != 0) else None)), 0)
+            value:
+            # ROUND(AVG(((TCP_TCC_WRITE_REQ_LATENCY_sum / (TCP_TCC_WRITE_REQ_sum +
+            #   TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) if ((TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
+            #   != 0) else None)), 0)
             alias: l2_wr_lat_
-            tips: 
+            tips:
           Fabric Rd Lat:
-            value: ROUND(AVG(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum
+            value:
+              ROUND(AVG(((TCC_EA0_RDREQ_LEVEL_sum / TCC_EA0_RDREQ_sum) if (TCC_EA0_RDREQ_sum
               != 0) else None)), 0)
             alias: fabric_rd_lat_
-            tips: 
+            tips:
           Fabric Wr Lat:
-            value: ROUND(AVG(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum
+            value:
+              ROUND(AVG(((TCC_EA0_WRREQ_LEVEL_sum / TCC_EA0_WRREQ_sum) if (TCC_EA0_WRREQ_sum
               != 0) else None)), 0)
             alias: fabric_wr_lat_
-            tips: 
+            tips:
           Fabric Atomic Lat:
-            value: ROUND(AVG(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
+            value:
+              ROUND(AVG(((TCC_EA0_ATOMIC_LEVEL_sum / TCC_EA0_ATOMIC_sum) if (TCC_EA0_ATOMIC_sum
               != 0) else None)), 0)
             alias: fabric_atom_lat_
-            tips: 
+            tips:
           Fabric_L2 Rd:
             value: ROUND(AVG((TCC_EA0_RDREQ_sum / $denom)), 0)
             alias: l2_fabric_rd_
-            tips: 
+            tips:
           Fabric_L2 Wr:
             value: ROUND(AVG((TCC_EA0_WRREQ_sum / $denom)), 0)
             alias: l2_fabric_wr_
-            tips: 
+            tips:
           Fabric_l2 Atomic:
             value: ROUND(AVG((TCC_EA0_ATOMIC_sum / $denom)), 0)
             alias: l2_fabric_atom_
-            tips: 
+            tips:
           HBM Rd:
             value: ROUND(AVG((TCC_EA0_RDREQ_DRAM_sum / $denom)), 0)
             alias: hbm_rd_
-            tips: 
+            tips:
           HBM Wr:
             value: ROUND(AVG((TCC_EA0_WRREQ_DRAM_sum / $denom)), 0)
             alias: hbm_wr_
-            tips: 
+            tips:
           LDS Util:
-            value: ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
+            value:
+              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
               0)
             alias: lds_util_
-            tips: 
+            tips:
           VL1 Coalesce:
-            value: ROUND(AVG(((((TA_TOTAL_WAVEFRONTS_sum * 64) * 100) / (TCP_TOTAL_ACCESSES_sum
+            value:
+              ROUND(AVG(((((TA_TOTAL_WAVEFRONTS_sum * 64) * 100) / (TCP_TOTAL_ACCESSES_sum
               * 4)) if (TCP_TOTAL_ACCESSES_sum != 0) else 0)), 0)
             alias: vl1_coales_
-            tips: 
+            tips:
           VL1 Stall:
-            value: ROUND(AVG((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum) 
+            value:
+              ROUND(AVG((((100 * TCP_TCR_TCP_STALL_CYCLES_sum) / TCP_GATE_EN1_sum)
               if (TCP_GATE_EN1_sum != 0) else None)), 0)
             alias: vl1_stall_
-            tips: 
+            tips:
           LDS Lat:
-            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQ_INSTS_LDS) 
+            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQ_INSTS_LDS)
               if (SQ_INSTS_LDS != 0) else None)), 0)
             alias: lds_lat_
             coll_level: SQ_INST_LEVEL_LDS
             tips:
-          vL1D Lat: 
-            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQC_DCACHE_REQ) 
+          vL1D Lat:
+            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQC_DCACHE_REQ)
               if (SQC_DCACHE_REQ != 0) else None)), 0)
             alias: sl1_lat_
             tips:
-          IL1 Lat: 
-            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQC_ICACHE_REQ) 
+          IL1 Lat:
+            value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / SQC_ICACHE_REQ)
               if (SQC_ICACHE_REQ != 0) else None)), 0)
             alias: il1_lat_
             tips:
-          Wave Occupancy: 
+          Wave Occupancy:
             value: ROUND(AVG(((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / $numActiveCUs)), 0)
             alias: wave_occ_
             coll_level: SQ_LEVEL_WAVES

--- a/src/omniperf_analyze/configs/gfx942/0300_mem_chart.yaml
+++ b/src/omniperf_analyze/configs/gfx942/0300_mem_chart.yaml
@@ -77,19 +77,20 @@ Panel Config:
             tips:
           VGPR:
             #alias: vgpr_
-            value: ROUND(AVG(vgpr), 0)
+            value: ROUND(AVG(Arch_VGPR), 0)
             tips:
+          # Todo: add AGPRs
           SGPR:
             #alias: sgpr_
-            value: ROUND(AVG(sgpr), 0)
+            value: ROUND(AVG(SGPR), 0)
             tips:
           LDS Allocation:
             #alias: lds_alloc_
-            value: ROUND(AVG(lds), 0)
+            value: ROUND(AVG(LDS_Per_Workgroup), 0)
             tips:
           Scratch Allocation:
             #alias: scratch_alloc_
-            value: ROUND(AVG(scr), 0)
+            value: ROUND(AVG(Scratch_Per_Workitem), 0)
             tips:
           Wavefronts:
             #alias: wavefronts_


### PR DESCRIPTION
* Fix some numbers are not shown in mem-chart Exec Block.
* Copy over config from gfx942 to gfx940 and gfx941.