### PR TITLE
profile: fix parsing tcc per channel on mi300 

### DIFF
--- a/src/omniperf
+++ b/src/omniperf
@@ -910,7 +910,6 @@ def main():
     # ANALYZE MODE
     ##############
     if args.mode == "analyze":
-
         if args.path:
             if ".." in str(args.path):
                 throw_parse_error(
@@ -939,9 +938,7 @@ def main():
                 if not os.path.isdir(dir[0]):
                     throw_parse_error(
                         my_parser,
-                        "Error: invalid directory {}\nPlease try again.".format(
-                            dir[0]
-                        ),
+                        "Error: invalid directory {}\nPlease try again.".format(dir[0]),
                     )
                 isWorkloadEmpty(
                     my_parser, dir[0]

--- a/src/omniperf
+++ b/src/omniperf
@@ -489,6 +489,7 @@ def run_prof(fname, workload_dir, perfmon_dir, cmd, target, log_file, verbose):
         or os.path.basename(fname) == "pmc_perf_14.txt"
         or os.path.basename(fname) == "pmc_perf_15.txt"
         or os.path.basename(fname) == "pmc_perf_16.txt"
+        or os.path.basename(fname) == "pmc_perf_17.txt"
     ):
         # FIXME: remove all hack code specific to pmc_perf_*.txt
         new_env = os.environ.copy()
@@ -519,6 +520,7 @@ def run_prof(fname, workload_dir, perfmon_dir, cmd, target, log_file, verbose):
         or os.path.basename(fname) == "pmc_perf_14.txt"
         or os.path.basename(fname) == "pmc_perf_15.txt"
         or os.path.basename(fname) == "pmc_perf_16.txt"
+        or os.path.basename(fname) == "pmc_perf_17.txt"
     ):
         # FIXME: remove all hack code specific to pmc_perf_*.txt
         new_env = os.environ.copy()

--- a/src/utils/perfagg.py
+++ b/src/utils/perfagg.py
@@ -620,9 +620,9 @@ def flatten_tcc_info_across_hbm_stacks(file, stack_num, tcc_channel_per_stack):
     for col in tcc_cols_orig:
         for i in range(0, stack_num):
             # filter the channel index only
-            p = re.compile(r"(\d+)")
+            p = re.compile(r"\[(\d+)\]")
             # pick up the 1st element only
-            r = lambda match: str(int(float(match.group(0))) + i * tcc_channel_per_stack)
+            r = lambda match: "[" + str(int(match.group(1)) + i * tcc_channel_per_stack) + "]"
             tcc_cols_in_group[i].append(re.sub(pattern=p, repl=r, string=col))
 
     for i in range(0, stack_num):


### PR DESCRIPTION
When profiling on mi300, some of the hw counter names might contain numbers as well.
The original regex doesn't work properly in that case. 