### PR TITLE
Escape sbios, can have commas on some systems

### DIFF
--- a/src/utils/specs.py
+++ b/src/utils/specs.py
@@ -297,7 +297,7 @@ def get_machine_specs(devicenum):
     device = rf"^\s*{devicenum}(.*)"
 
     hostname = socket.gethostname()
-    sbios = (
+    sbios = str(
         path("/sys/class/dmi/id/bios_vendor").read_text().strip()
         + path("/sys/class/dmi/id/bios_version").read_text().strip()
     )

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -315,7 +315,7 @@ def gen_sysinfo(workload_name, workload_dir, ip_blocks, app_cmd, skip_roof, roof
     param += [
         mspec.hostname,
         mspec.CPU,
-        mspec.sbios,
+        '"' + mspec.sbios + '"',
         mspec.distro,
         mspec.kernel_version,
         mspec.rocm_version,

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -315,7 +315,7 @@ def gen_sysinfo(workload_name, workload_dir, ip_blocks, app_cmd, skip_roof, roof
     param += [
         mspec.hostname,
         mspec.CPU,
-        '"' + mspec.sbios + '"',
+        mspec.sbios,
         mspec.distro,
         mspec.kernel_version,
         mspec.rocm_version,


### PR DESCRIPTION
Not sure if the other fields can do this either (at a guess, we might just want to escape anything that's not known to be a number), but this fixes the system-info table on my machine