### PR TITLE
Various mi300 metric fixes

### DIFF
--- a/src/omniperf_soc/analysis_configs/gfx906/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/0200_system-speed-of-light.yaml
@@ -166,9 +166,9 @@ Panel Config:
           L2 Cache BW:
             value: AVG(((TCC_REQ_sum * 64) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 64) * TO_INT($L2Banks))
+            peak: ((($sclk / 1000) * 64) * TO_INT($totalL2Banks))
             pop: ((100 * AVG(((TCC_REQ_sum * 64) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 64) * TO_INT($L2Banks)))
+              / ((($sclk / 1000) * 64) * TO_INT($totalL2Banks)))
             tips: 
           L2-Fabric Read BW:
             value: AVG((((TCC_EA_RDREQ_32B_sum * 32) + ((TCC_EA_RDREQ_sum - TCC_EA_RDREQ_32B_sum)

--- a/src/omniperf_soc/analysis_configs/gfx906/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/1700_L2_cache.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($totalL2Banks) * GRBM_GUI_ACTIVE)))
             unit: pct
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCC_REQ_sum * 64) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 64) * TO_INT($L2Banks)))
+            value: ((100 * AVG(((TCC_REQ_sum * 64) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 64) * TO_INT($totalL2Banks)))
             unit: pct
             tips: 
           Hit Rate:

--- a/src/omniperf_soc/analysis_configs/gfx908/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/0200_system-speed-of-light.yaml
@@ -166,9 +166,9 @@ Panel Config:
           L2 Cache BW:
             value: AVG(((TCC_REQ_sum * 64) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 64) * TO_INT($L2Banks))
+            peak: ((($sclk / 1000) * 64) * TO_INT($totalL2Banks))
             pop: ((100 * AVG(((TCC_REQ_sum * 64) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 64) * TO_INT($L2Banks)))
+              / ((($sclk / 1000) * 64) * TO_INT($totalL2Banks)))
             tips: 
           L2-Fabric Read BW:
             value: AVG((((TCC_EA_RDREQ_32B_sum * 32) + ((TCC_EA_RDREQ_sum - TCC_EA_RDREQ_32B_sum)

--- a/src/omniperf_soc/analysis_configs/gfx908/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/1700_L2_cache.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($totalL2Banks) * GRBM_GUI_ACTIVE)))
             unit: pct
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCC_REQ_sum * 64) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 64) * TO_INT($L2Banks)))
+            value: ((100 * AVG(((TCC_REQ_sum * 64) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 64) * TO_INT($totalL2Banks)))
             unit: pct
             tips: 
           Hit Rate:

--- a/src/omniperf_soc/analysis_configs/gfx90a/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/0200_system-speed-of-light.yaml
@@ -183,9 +183,9 @@ Panel Config:
           L2 Cache BW:
             value: AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 128) * TO_INT($L2Banks))
+            peak: ((($sclk / 1000) * 128) * TO_INT($totalL2Banks))
             pop: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
+              / ((($sclk / 1000) * 128) * TO_INT($totalL2Banks)))
             tips: 
           L2-Fabric Read BW:
             value: AVG((((TCC_EA_RDREQ_32B_sum * 32) + ((TCC_EA_RDREQ_sum - TCC_EA_RDREQ_32B_sum)

--- a/src/omniperf_soc/analysis_configs/gfx90a/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/1700_L2_cache.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($totalL2Banks) * GRBM_GUI_ACTIVE)))
             unit: pct
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
+            value: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 128) * TO_INT($totalL2Banks)))
             unit: pct
             tips: 
           Hit Rate:

--- a/src/omniperf_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
@@ -166,11 +166,11 @@ Panel Config:
               None))
             tips: 
           vL1D Cache BW:
-            value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp)))
+            value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 64) * $numCU)
-            pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 64) * $numCU))
+            peak: ((($sclk / 1000) * 128) * $numCU)
+            pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp))))
+              / ((($sclk / 1000) * 128) * $numCU))
             tips: 
           L2 Cache Hit Rate:
             value: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum

--- a/src/omniperf_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
@@ -183,9 +183,9 @@ Panel Config:
           L2 Cache BW:
             value: AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 128) * TO_INT($L2Banks))
+            peak: ((($sclk / 1000) * 128) * TO_INT($totalL2Banks))
             pop: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
+              / ((($sclk / 1000) * 128) * TO_INT($totalL2Banks)))
             tips: 
           L2-Fabric Read BW:
             value: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)

--- a/src/omniperf_soc/analysis_configs/gfx940/1000_compute-unit-instruction-mix.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/1000_compute-unit-instruction-mix.yaml
@@ -26,12 +26,16 @@ Panel Config:
             unit: (instr + $normUnit)
             tips: 
           VMEM:
-            avg: AVG(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
-            min: MIN(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
-            max: MAX(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
+            # TODO: need to fix this when the new FLAT/LDS counts
+            # are present in ROCm
+            avg: AVG(((SQ_INSTS_VMEM) / $denom))
+            min: MIN(((SQ_INSTS_VMEM) / $denom))
+            max: MAX(((SQ_INSTS_VMEM) / $denom))
             unit: (instr + $normUnit)
             tips: 
           LDS:
+            # TODO: need to fix this when the new FLAT/LDS counts
+            # are present in ROCm
             avg: AVG((SQ_INSTS_LDS / $denom))
             min: MIN((SQ_INSTS_LDS / $denom))
             max: MAX((SQ_INSTS_LDS / $denom))

--- a/src/omniperf_soc/analysis_configs/gfx940/1600_L1_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/1600_L1_cache.yaml
@@ -25,8 +25,8 @@ Panel Config:
             unit: Pct of Peak
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 64) * $numCU))
+            value: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp))))
+              / ((($sclk / 1000) * 128) * $numCU))
             unit: Pct of Peak
             tips:
           Utilization:
@@ -116,9 +116,9 @@ Panel Config:
             unit: (Req  + $normUnit)
             tips:
           Cache BW:
-            avg: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
-            min: MIN(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
-            max: MAX(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
+            avg: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
+            min: MIN(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
+            max: MAX(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
             unit: (Bytes + $normUnit)
             tips:
           Cache Hit Rate:

--- a/src/omniperf_soc/analysis_configs/gfx940/1600_L1_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/1600_L1_cache.yaml
@@ -161,12 +161,15 @@ Panel Config:
             unit: (Req + $normUnit)
             tips:
           L1-L2 BW:
-            avg: AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            min: MIN(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            max: MAX(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            avg: AVG(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            min: MIN(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            max: MAX(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
           L1-L2 Read:

--- a/src/omniperf_soc/analysis_configs/gfx940/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/1700_L2_cache.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($totalL2Banks) * GRBM_GUI_ACTIVE)))
             unit: pct
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
+            value: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 128) * TO_INT($totalL2Banks)))
             unit: pct
             tips: 
           Hit Rate:

--- a/src/omniperf_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
@@ -166,11 +166,11 @@ Panel Config:
               None))
             tips: 
           vL1D Cache BW:
-            value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp)))
+            value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 64) * $numCU)
-            pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 64) * $numCU))
+            peak: ((($sclk / 1000) * 128) * $numCU)
+            pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp))))
+              / ((($sclk / 1000) * 128) * $numCU))
             tips: 
           L2 Cache Hit Rate:
             value: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum

--- a/src/omniperf_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
@@ -183,9 +183,9 @@ Panel Config:
           L2 Cache BW:
             value: AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 128) * TO_INT($L2Banks))
+            peak: ((($sclk / 1000) * 128) * TO_INT($totalL2Banks))
             pop: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
+              / ((($sclk / 1000) * 128) * TO_INT($totalL2Banks)))
             tips: 
           L2-Fabric Read BW:
             value: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)

--- a/src/omniperf_soc/analysis_configs/gfx941/1000_compute-unit-instruction-mix.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/1000_compute-unit-instruction-mix.yaml
@@ -26,12 +26,16 @@ Panel Config:
             unit: (instr + $normUnit)
             tips: 
           VMEM:
-            avg: AVG(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
-            min: MIN(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
-            max: MAX(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
+            # TODO: need to fix this when the new FLAT/LDS counts
+            # are present in ROCm
+            avg: AVG(((SQ_INSTS_VMEM) / $denom))
+            min: MIN(((SQ_INSTS_VMEM) / $denom))
+            max: MAX(((SQ_INSTS_VMEM) / $denom))
             unit: (instr + $normUnit)
             tips: 
           LDS:
+            # TODO: need to fix this when the new FLAT/LDS counts
+            # are present in ROCm
             avg: AVG((SQ_INSTS_LDS / $denom))
             min: MIN((SQ_INSTS_LDS / $denom))
             max: MAX((SQ_INSTS_LDS / $denom))

--- a/src/omniperf_soc/analysis_configs/gfx941/1600_L1_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/1600_L1_cache.yaml
@@ -25,8 +25,8 @@ Panel Config:
             unit: Pct of Peak
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 64) * $numCU))
+            value: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp))))
+              / ((($sclk / 1000) * 128) * $numCU))
             unit: Pct of Peak
             tips:
           Utilization:
@@ -116,9 +116,9 @@ Panel Config:
             unit: (Req  + $normUnit)
             tips:
           Cache BW:
-            avg: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
-            min: MIN(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
-            max: MAX(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
+            avg: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
+            min: MIN(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
+            max: MAX(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
             unit: (Bytes + $normUnit)
             tips:
           Cache Hit Rate:

--- a/src/omniperf_soc/analysis_configs/gfx941/1600_L1_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/1600_L1_cache.yaml
@@ -161,12 +161,15 @@ Panel Config:
             unit: (Req + $normUnit)
             tips:
           L1-L2 BW:
-            avg: AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            min: MIN(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            max: MAX(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            avg: AVG(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            min: MIN(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            max: MAX(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
           L1-L2 Read:

--- a/src/omniperf_soc/analysis_configs/gfx941/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/1700_L2_cache.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($totalL2Banks) * GRBM_GUI_ACTIVE)))
             unit: pct
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
+            value: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 128) * TO_INT($totalL2Banks)))
             unit: pct
             tips: 
           Hit Rate:

--- a/src/omniperf_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
@@ -183,9 +183,9 @@ Panel Config:
           L2 Cache BW:
             value: AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 128) * TO_INT($L2Banks))
+            peak: ((($sclk / 1000) * 128) * TO_INT($totalL2Banks))
             pop: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
+              / ((($sclk / 1000) * 128) * TO_INT($totalL2Banks)))
             tips: 
           L2-Fabric Read BW:
             value: AVG((128 * TCC_BUBBLE_sum +

--- a/src/omniperf_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
@@ -188,12 +188,14 @@ Panel Config:
               / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
             tips: 
           L2-Fabric Read BW:
-            value: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
-              * 64)) / (End_Timestamp - Start_Timestamp)))
+            value: AVG((128 * TCC_BUBBLE_sum +
+                        64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) + 
+                        32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp - Start_Timestamp))
             unit: GB/s
             peak: $hbmBW
-            pop: ((100 * AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
-              * 64)) / (End_Timestamp - Start_Timestamp)))) / $hbmBW)
+            pop: ((100 * (AVG((128 * TCC_BUBBLE_sum +
+                        64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) + 
+                        32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp - Start_Timestamp)))) / $hbmBW)
             tips: 
           L2-Fabric Write BW:
             value: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)

--- a/src/omniperf_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
@@ -166,11 +166,11 @@ Panel Config:
               None))
             tips: 
           vL1D Cache BW:
-            value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp)))
+            value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
-            peak: ((($sclk / 1000) * 64) * $numCU)
-            pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 64) * $numCU))
+            peak: ((($sclk / 1000) * 128) * $numCU)
+            pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp))))
+              / ((($sclk / 1000) * 128) * $numCU))
             tips: 
           L2 Cache Hit Rate:
             value: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum

--- a/src/omniperf_soc/analysis_configs/gfx942/1000_compute-unit-instruction-mix.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1000_compute-unit-instruction-mix.yaml
@@ -26,12 +26,16 @@ Panel Config:
             unit: (instr + $normUnit)
             tips: 
           VMEM:
-            avg: AVG(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
-            min: MIN(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
-            max: MAX(((SQ_INSTS_VMEM - SQ_INSTS_FLAT_LDS_ONLY) / $denom))
+            # TODO: need to fix this when the new FLAT/LDS counts
+            # are present in ROCm
+            avg: AVG(((SQ_INSTS_VMEM) / $denom))
+            min: MIN(((SQ_INSTS_VMEM) / $denom))
+            max: MAX(((SQ_INSTS_VMEM) / $denom))
             unit: (instr + $normUnit)
             tips: 
           LDS:
+            # TODO: need to fix this when the new FLAT/LDS counts
+            # are present in ROCm
             avg: AVG((SQ_INSTS_LDS / $denom))
             min: MIN((SQ_INSTS_LDS / $denom))
             max: MAX((SQ_INSTS_LDS / $denom))

--- a/src/omniperf_soc/analysis_configs/gfx942/1600_L1_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1600_L1_cache.yaml
@@ -25,8 +25,8 @@ Panel Config:
             unit: Pct of Peak
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / (End_Timestamp - Start_Timestamp))))
-              / ((($sclk / 1000) * 64) * $numCU))
+            value: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp))))
+              / ((($sclk / 1000) * 128) * $numCU))
             unit: Pct of Peak
             tips:
           Utilization:
@@ -116,9 +116,9 @@ Panel Config:
             unit: (Req  + $normUnit)
             tips:
           Cache BW:
-            avg: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
-            min: MIN(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
-            max: MAX(((TCP_TOTAL_CACHE_ACCESSES_sum * 64) / $denom))
+            avg: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
+            min: MIN(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
+            max: MAX(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / $denom))
             unit: (Bytes + $normUnit)
             tips:
           Cache Hit Rate:

--- a/src/omniperf_soc/analysis_configs/gfx942/1600_L1_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1600_L1_cache.yaml
@@ -161,12 +161,15 @@ Panel Config:
             unit: (Req + $normUnit)
             tips:
           L1-L2 BW:
-            avg: AVG(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            min: MIN(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
-            max: MAX(((64 * (((TCP_TCC_READ_REQ_sum + TCP_TCC_WRITE_REQ_sum) + TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
-              + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            avg: AVG(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            min: MIN(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
+            max: MAX(((128 * TCP_TCC_READ_REQ_sum + 64 *
+                      (TCP_TCC_WRITE_REQ_sum + TCP_TCC_ATOMIC_WITH_RET_REQ_sum +
+                        TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
           L1-L2 Read:

--- a/src/omniperf_soc/analysis_configs/gfx942/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1700_L2_cache.yaml
@@ -54,12 +54,15 @@ Panel Config:
           tips: Tips
         metric:
           L2-Fabric Read BW:
-            avg: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
-              * 64)) / $denom))
-            min: MIN((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
-              * 64)) / $denom))
-            max: MAX((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
-              * 64)) / $denom))
+            avg: AVG(((128 * TCC_BUBBLE_sum +
+                        64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) +
+                        32 * TCC_EA0_RDREQ_32B_sum) / $denom))
+            min: MIN(((128 * TCC_BUBBLE_sum +
+                        64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) +
+                        32 * TCC_EA0_RDREQ_32B_sum) / $denom))
+            max: MAX(((128 * TCC_BUBBLE_sum +
+                        64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) +
+                        32 * TCC_EA0_RDREQ_32B_sum) / $denom))
             unit: (Bytes  + $normUnit)
             tips:
           HBM Read Traffic:
@@ -381,9 +384,15 @@ Panel Config:
             unit: (Req  + $normUnit)
             tips:
           Read (64B):
-            avg: AVG(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
-            min: MIN(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
-            max: MAX(((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
+            avg: AVG(((TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
+            min: MIN(((TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
+            max: MAX(((TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) / $denom))
+            unit: (Req  + $normUnit)
+            tips:
+          Read (128B):
+            avg: AVG(((TCC_BUBBLE_sum) / $denom))
+            min: MIN(((TCC_BUBBLE_sum) / $denom))
+            max: MAX(((TCC_BUBBLE_sum) / $denom))
             unit: (Req  + $normUnit)
             tips:
           HBM Read:

--- a/src/omniperf_soc/analysis_configs/gfx942/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1700_L2_cache.yaml
@@ -31,8 +31,9 @@ Panel Config:
             unit: pct
             tips:
           L2-Fabric Read BW:
-            value: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + ((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_32B_sum)
-              * 64)) / (End_Timestamp - Start_Timestamp)))
+            value: AVG((128 * TCC_BUBBLE_sum +
+                        64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum) +
+                        32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp - Start_Timestamp))
             unit: GB/s
             tips:
           L2-Fabric Write and Atomic BW:

--- a/src/omniperf_soc/analysis_configs/gfx942/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1700_L2_cache.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($totalL2Banks) * GRBM_GUI_ACTIVE)))
             unit: pct
             tips:
           Bandwidth:
-            value: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 128) * TO_INT($L2Banks)))
+            value: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))) / ((($sclk / 1000) * 128) * TO_INT($totalL2Banks)))
             unit: pct
             tips: 
           Hit Rate:

--- a/src/omniperf_soc/profile_configs/gfx940/pmc_tcc_perf.txt
+++ b/src/omniperf_soc/profile_configs/gfx940/pmc_tcc_perf.txt
@@ -5,7 +5,8 @@ pmc: TCC_NC_REQ_sum                         TCC_UC_REQ_sum                      
 pmc: TCC_REQ_sum                            TCC_STREAMING_REQ_sum                 TCC_HIT_sum                            TCC_MISS_sum
 pmc: TCC_READ_sum                           TCC_WRITE_sum                         TCC_ATOMIC_sum                         TCC_WRITEBACK_sum
 pmc: TCC_EA0_WRREQ_sum                       TCC_EA0_WRREQ_64B_sum                  TCC_EA0_WR_UNCACHED_32B_sum         TCC_EA0_WRREQ_DRAM_sum                             
-pmc: TCC_EA0_RDREQ_sum                      TCC_EA0_RDREQ_32B_sum                   TCC_EA0_RD_UNCACHED_32B_sum            TCC_EA0_RDREQ_DRAM_sum
+pmc: TCC_EA0_RDREQ_sum                      TCC_EA0_RDREQ_32B_sum                   TCC_BUBBLE_sum
+pmc: TCC_EA0_RD_UNCACHED_32B_sum            TCC_EA0_RDREQ_DRAM_sum
 pmc: TCC_TAG_STALL_sum                      TCC_NORMAL_WRITEBACK_sum              TCC_ALL_TC_OP_WB_WRITEBACK_sum         TCC_NORMAL_EVICT_sum
 pmc: TCC_ALL_TC_OP_INV_EVICT_sum            TCC_TOO_MANY_EA_WRREQS_STALL_sum      TCC_EA0_ATOMIC_sum                           
 pmc: TCC_EA0_RDREQ_LEVEL_sum                 TCC_EA0_WRREQ_LEVEL_sum                TCC_EA0_ATOMIC_LEVEL_sum            TCC_EA0_WRREQ_STALL_sum

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -285,7 +285,7 @@ def build_eval_string(equation, coll_level):
     # build-in variable starts with '$', python can not handle it.
     # replace '$' with 'ammolite__'.
     # TODO: pre-check there is no "ammolite__" in all config files.
-    s = re.sub("\$", "ammolite__", s)
+    s = re.sub(r"\$", "ammolite__", s)
 
     # convert equation string to intermediate expression in df array format
     ast_node = ast.parse(s)
@@ -299,7 +299,7 @@ def build_eval_string(equation, coll_level):
     # the target is df['TCC_HIT[0]']
     s = re.sub(r"\'\]\[(\d+)\]", r"[\g<1>]']", s)
     # use .get() to catch any potential KeyErrors
-    s = re.sub("raw_pmc_df\['(.*?)']", r'raw_pmc_df.get("\1")', s)
+    s = re.sub(r"raw_pmc_df\['(.*?)']", r'raw_pmc_df.get("\1")', s)
     # apply coll_level
     s = re.sub(r"raw_pmc_df", "raw_pmc_df.get('" + coll_level + "')", s)
     # print("--- build_eval_string, return: ", s)


### PR DESCRIPTION
Most of the fixes for MI300:

- fixes L1/L2/fabric bandwidths
- work around VMEM/FLAT instruction changes while work internally is pending
- use totalL2Banks everywhere for consistency & correctness