### PR TITLE
Fix for MI300 clock timings using GRBM_GUI_ACTIVE

### DIFF
--- a/src/omniperf_soc/analysis_configs/gfx906/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/0200_system-speed-of-light.yaml
@@ -69,16 +69,16 @@ Panel Config:
             pop: ((100 * $numActiveCUs) / $numCU)
             tips: 
           SALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           VALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips:
           MFMA Utilization:
             value: None # No HW module
@@ -113,10 +113,10 @@ Panel Config:
             pop: ((100 * AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))) / 5)
             tips: 
           Wavefront Occupancy:
-            value: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            value: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             peak: ($maxWavesPerCU * $numCU)
-            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / ($maxWavesPerCU
+            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / ($maxWavesPerCU
               * $numCU))))
             coll_level: SQ_LEVEL_WAVES
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx906/0300_mem_chart.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/0300_mem_chart.yaml
@@ -23,7 +23,7 @@ Panel Config:
           #TODO: double check wave_occupancy
           Wavefront Occupancy:
             #alias: wave_occ_
-            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / $numActiveCUs), 0)
+            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / $numActiveCUs), 0)
             coll_level: SQ_LEVEL_WAVES
             tips:
           Wave Life:
@@ -110,7 +110,7 @@ Panel Config:
           LDS Util:
             #alias: lds_util_
             value:
-              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
+              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))),
               0)
             tips:
           LDS Latency:

--- a/src/omniperf_soc/analysis_configs/gfx906/0600_shader-processor-input.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/0600_shader-processor-input.yaml
@@ -20,33 +20,33 @@ Panel Config:
           tips: Tips
         metric:
           Accelerator Utilization:
-            avg: AVG(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            min: MIN(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            max: MAX(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
+            avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            max: MAX(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             unit: Pct
             tips: 
           Scheduler-Pipe Utilization:
-            avg: AVG(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            min: MIN(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            max: MAX(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
+            avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
             unit: Pct
             tips: 
           Workgroup Manager Utilization:
-            avg: AVG(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            min: MIN(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            max: MAX(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
+            avg: AVG(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
             unit: Pct
             tips: 
           Shader Engine Utilization:
-            avg: AVG(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            min: MIN(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            max: MAX(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
+            avg: AVG(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            min: MIN(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            max: MAX(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
             unit: Pct
             tips: 
           SIMD Utilization:
-            avg: AVG(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Dispatched Workgroups:
@@ -91,77 +91,77 @@ Panel Config:
           tips: Tips
         metric:
           Not-scheduled Rate (Workgroup Manager):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Not-scheduled Rate (Scheduler-Pipe):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Scheduler-Pipe Stall Rate:
-            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
             unit: Pct
             tips: 
           Scratch Stall Rate:
-            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            min: MIN((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            max: MAX((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
+            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            min: MIN((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            max: MAX((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
             unit: Pct
             tips: 
           Insufficient SIMD Waveslots:
-            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD VGPRs:
-            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD SGPRs:
-            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU LDS:
-            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU Barriers:
-            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Workgroup Limit:
-            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Wavefront Limit:
-            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx906/0700_wavefront-launch.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/0700_wavefront-launch.yaml
@@ -98,9 +98,9 @@ Panel Config:
             unit: ns
             tips: 
           Kernel Time (Cycles):
-            avg: AVG(GRBM_GUI_ACTIVE)
-            min: MIN(GRBM_GUI_ACTIVE)
-            max: MAX(GRBM_GUI_ACTIVE)
+            avg: AVG($GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN($GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX($GRBM_GUI_ACTIVE_PER_XCD)
             unit: Cycle
             tips: 
           Instructions per wavefront:
@@ -134,9 +134,9 @@ Panel Config:
             unit: (Cycles + $normUnit)
             tips: 
           Wavefront Occupancy:
-            avg: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            min: MIN((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            max: MAX((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            avg: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            min: MIN((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            max: MAX((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             coll_level: SQ_LEVEL_WAVES
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx906/1100_compute-unit-compute-pipeline.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/1100_compute-unit-compute-pipeline.yaml
@@ -92,15 +92,15 @@ Panel Config:
             unit: Instr/cycle
             tips: 
           SALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VMEM Utilization:

--- a/src/omniperf_soc/analysis_configs/gfx906/1200_lds.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/1200_lds.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips: 
           Access Rate:
-            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips: 
           Theoretical Bandwidth (% of Peak):

--- a/src/omniperf_soc/analysis_configs/gfx906/1500_TA_and_TD.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/1500_TA_and_TD.yaml
@@ -20,27 +20,27 @@ Panel Config:
           tips: Tips
         metric:
           Address Processing Unit Busy:
-            avg: AVG(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data Stall:
-            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data-Processor → Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Total Instructions:
@@ -128,15 +128,15 @@ Panel Config:
           tips: Tips
         metric:
           Data-Return Busy:
-            avg: AVG(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Cache RAM → Data-Return Stall:
-            avg: AVG(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Workgroup manager → Data-Return Stall:

--- a/src/omniperf_soc/analysis_configs/gfx906/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx906/1700_L2_cache.yaml
@@ -18,7 +18,7 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips:
           Bandwidth:

--- a/src/omniperf_soc/analysis_configs/gfx908/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/0200_system-speed-of-light.yaml
@@ -69,16 +69,16 @@ Panel Config:
             pop: ((100 * $numActiveCUs) / $numCU)
             tips: 
           SALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           VALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips:
           MFMA Utilization:
             value: None # No HW module
@@ -113,10 +113,10 @@ Panel Config:
             pop: ((100 * AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))) / 5)
             tips: 
           Wavefront Occupancy:
-            value: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            value: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             peak: ($maxWavesPerCU * $numCU)
-            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / ($maxWavesPerCU
+            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / ($maxWavesPerCU
               * $numCU))))
             coll_level: SQ_LEVEL_WAVES
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx908/0300_mem_chart.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/0300_mem_chart.yaml
@@ -23,7 +23,7 @@ Panel Config:
           #TODO: double check wave_occupancy
           Wavefront Occupancy:
             #alias: wave_occ_
-            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / $numActiveCUs), 0)
+            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / $numActiveCUs), 0)
             coll_level: SQ_LEVEL_WAVES
             tips:
           Wave Life:
@@ -110,7 +110,7 @@ Panel Config:
           LDS Util:
             #alias: lds_util_
             value:
-              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
+              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))),
               0)
             tips:
           LDS Latency:

--- a/src/omniperf_soc/analysis_configs/gfx908/0600_shader-processor-input.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/0600_shader-processor-input.yaml
@@ -20,33 +20,33 @@ Panel Config:
           tips: Tips
         metric:
           Accelerator Utilization:
-            avg: AVG(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            min: MIN(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            max: MAX(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
+            avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            max: MAX(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             unit: Pct
             tips: 
           Scheduler-Pipe Utilization:
-            avg: AVG(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            min: MIN(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            max: MAX(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
+            avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
             unit: Pct
             tips: 
           Workgroup Manager Utilization:
-            avg: AVG(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            min: MIN(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            max: MAX(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
+            avg: AVG(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
             unit: Pct
             tips: 
           Shader Engine Utilization:
-            avg: AVG(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            min: MIN(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            max: MAX(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
+            avg: AVG(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            min: MIN(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            max: MAX(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
             unit: Pct
             tips: 
           SIMD Utilization:
-            avg: AVG(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Dispatched Workgroups:
@@ -91,77 +91,77 @@ Panel Config:
           tips: Tips
         metric:
           Not-scheduled Rate (Workgroup Manager):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Not-scheduled Rate (Scheduler-Pipe):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Scheduler-Pipe Stall Rate:
-            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
             unit: Pct
             tips: 
           Scratch Stall Rate:
-            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            min: MIN((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            max: MAX((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
+            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            min: MIN((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            max: MAX((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
             unit: Pct
             tips: 
           Insufficient SIMD Waveslots:
-            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD VGPRs:
-            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD SGPRs:
-            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU LDS:
-            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU Barriers:
-            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Workgroup Limit:
-            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Wavefront Limit:
-            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx908/0700_wavefront-launch.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/0700_wavefront-launch.yaml
@@ -98,9 +98,9 @@ Panel Config:
             unit: ns
             tips: 
           Kernel Time (Cycles):
-            avg: AVG(GRBM_GUI_ACTIVE)
-            min: MIN(GRBM_GUI_ACTIVE)
-            max: MAX(GRBM_GUI_ACTIVE)
+            avg: AVG($GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN($GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX($GRBM_GUI_ACTIVE_PER_XCD)
             unit: Cycle
             tips: 
           Instructions per wavefront:
@@ -134,9 +134,9 @@ Panel Config:
             unit: (Cycles + $normUnit)
             tips: 
           Wavefront Occupancy:
-            avg: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            min: MIN((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            max: MAX((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            avg: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            min: MIN((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            max: MAX((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             coll_level: SQ_LEVEL_WAVES
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx908/1100_compute-unit-compute-pipeline.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/1100_compute-unit-compute-pipeline.yaml
@@ -92,15 +92,15 @@ Panel Config:
             unit: Instr/cycle
             tips: 
           SALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VMEM Utilization:

--- a/src/omniperf_soc/analysis_configs/gfx908/1200_lds.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/1200_lds.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips: 
           Access Rate:
-            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips: 
             unit: pct

--- a/src/omniperf_soc/analysis_configs/gfx908/1500_TA_and_TD.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/1500_TA_and_TD.yaml
@@ -20,27 +20,27 @@ Panel Config:
           tips: Tips
         metric:
           Address Processing Unit Busy:
-            avg: AVG(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data Stall:
-            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data-Processor → Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Total Instructions:
@@ -128,15 +128,15 @@ Panel Config:
           tips: Tips
         metric:
           Data-Return Busy:
-            avg: AVG(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Cache RAM → Data-Return Stall:
-            avg: AVG(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Workgroup manager → Data-Return Stall:

--- a/src/omniperf_soc/analysis_configs/gfx908/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx908/1700_L2_cache.yaml
@@ -18,7 +18,7 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips:
           Bandwidth:

--- a/src/omniperf_soc/analysis_configs/gfx90a/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/0200_system-speed-of-light.yaml
@@ -84,36 +84,36 @@ Panel Config:
             pop: ((100 * $numActiveCUs) / $numCU)
             tips: 
           SALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           VALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           MFMA Utilization:
-            value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((GRBM_GUI_ACTIVE * $numCU)
+            value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD * $numCU)
               * 4)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((GRBM_GUI_ACTIVE * $numCU)
+            pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD * $numCU)
               * 4)))
             tips: 
           VMEM Utilization:
-            value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             peak: 100
-            pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             tips: 
           Branch Utilization:
-            value: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            value: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             peak: 100
-            pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             tips: 
           VALU Active Threads:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
@@ -130,10 +130,10 @@ Panel Config:
             pop: ((100 * AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))) / 5)
             tips: 
           Wavefront Occupancy:
-            value: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            value: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             peak: ($maxWavesPerCU * $numCU)
-            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / ($maxWavesPerCU
+            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / ($maxWavesPerCU
               * $numCU))))
             coll_level: SQ_LEVEL_WAVES
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx90a/0300_mem_chart.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/0300_mem_chart.yaml
@@ -23,7 +23,7 @@ Panel Config:
           #TODO: double check wave_occupancy
           Wavefront Occupancy:
             #alias: wave_occ_
-            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / $numActiveCUs), 0)
+            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / $numActiveCUs), 0)
             coll_level: SQ_LEVEL_WAVES
             tips:
           Wave Life:
@@ -111,7 +111,7 @@ Panel Config:
           LDS Util:
             #alias: lds_util_
             value:
-              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
+              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))),
               0)
             tips:
           LDS Latency:

--- a/src/omniperf_soc/analysis_configs/gfx90a/0600_shader-processor-input.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/0600_shader-processor-input.yaml
@@ -20,33 +20,33 @@ Panel Config:
           tips: Tips
         metric:
           Accelerator Utilization:
-            avg: AVG(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            min: MIN(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            max: MAX(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
+            avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            max: MAX(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             unit: Pct
             tips: 
           Scheduler-Pipe Utilization:
-            avg: AVG(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            min: MIN(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            max: MAX(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
+            avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
             unit: Pct
             tips: 
           Workgroup Manager Utilization:
-            avg: AVG(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            min: MIN(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            max: MAX(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
+            avg: AVG(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
             unit: Pct
             tips: 
           Shader Engine Utilization:
-            avg: AVG(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            min: MIN(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            max: MAX(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
+            avg: AVG(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            min: MIN(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            max: MAX(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
             unit: Pct
             tips: 
           SIMD Utilization:
-            avg: AVG(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Dispatched Workgroups:
@@ -91,77 +91,77 @@ Panel Config:
           tips: Tips
         metric:
           Not-scheduled Rate (Workgroup Manager):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Not-scheduled Rate (Scheduler-Pipe):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Scheduler-Pipe Stall Rate:
-            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
             unit: Pct
             tips: 
           Scratch Stall Rate:
-            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            min: MIN((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            max: MAX((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
+            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            min: MIN((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            max: MAX((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
             unit: Pct
             tips: 
           Insufficient SIMD Waveslots:
-            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD VGPRs:
-            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD SGPRs:
-            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU LDS:
-            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU Barriers:
-            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Workgroup Limit:
-            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Wavefront Limit:
-            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx90a/0700_wavefront-launch.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/0700_wavefront-launch.yaml
@@ -98,9 +98,9 @@ Panel Config:
             unit: ns
             tips: 
           Kernel Time (Cycles):
-            avg: AVG(GRBM_GUI_ACTIVE)
-            min: MIN(GRBM_GUI_ACTIVE)
-            max: MAX(GRBM_GUI_ACTIVE)
+            avg: AVG($GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN($GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX($GRBM_GUI_ACTIVE_PER_XCD)
             unit: Cycle
             tips: 
           Instructions per wavefront:
@@ -134,9 +134,9 @@ Panel Config:
             unit: (Cycles + $normUnit)
             tips: 
           Wavefront Occupancy:
-            avg: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            min: MIN((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            max: MAX((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            avg: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            min: MIN((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            max: MAX((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             coll_level: SQ_LEVEL_WAVES
             tips:  

--- a/src/omniperf_soc/analysis_configs/gfx90a/1100_compute-unit-compute-pipeline.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/1100_compute-unit-compute-pipeline.yaml
@@ -107,27 +107,27 @@ Panel Config:
             unit: Instr/cycle
             tips: 
           SALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VMEM Utilization:
-            avg: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           Branch Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Active Threads:
@@ -140,9 +140,9 @@ Panel Config:
             unit: Threads
             tips: 
           MFMA Utilization:
-            avg: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
-            min: MIN(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
-            max: MAX(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
+            avg: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
+            min: MIN(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
+            max: MAX(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips: 
           MFMA Instr Cycles:

--- a/src/omniperf_soc/analysis_configs/gfx90a/1200_lds.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/1200_lds.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips: 
           Access Rate:
-            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips: 
           Theoretical Bandwidth:

--- a/src/omniperf_soc/analysis_configs/gfx90a/1500_TA_and_TD.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/1500_TA_and_TD.yaml
@@ -20,27 +20,27 @@ Panel Config:
           tips: Tips
         metric:
           Address Processing Unit Busy:
-            avg: AVG(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data Stall:
-            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data-Processor → Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Total Instructions:
@@ -128,21 +128,21 @@ Panel Config:
           tips: Tips
         metric:
           Data-Return Busy:
-            avg: AVG(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Cache RAM → Data-Return Stall:
-            avg: AVG(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Workgroup manager → Data-Return Stall:
-            avg: AVG(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Coalescable Instructions:

--- a/src/omniperf_soc/analysis_configs/gfx90a/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx90a/1700_L2_cache.yaml
@@ -18,7 +18,7 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips:
           Bandwidth:

--- a/src/omniperf_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
@@ -84,36 +84,36 @@ Panel Config:
             pop: ((100 * $numActiveCUs) / $numCU)
             tips: 
           SALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           VALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           MFMA Utilization:
-            value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((GRBM_GUI_ACTIVE * $numCU)
+            value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD * $numCU)
               * 4)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((GRBM_GUI_ACTIVE * $numCU)
+            pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD * $numCU)
               * 4)))
             tips: 
           VMEM Utilization:
-            value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             peak: 100
-            pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             tips: 
           Branch Utilization:
-            value: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            value: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             peak: 100
-            pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             tips: 
           VALU Active Threads:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
@@ -130,10 +130,10 @@ Panel Config:
             pop: ((100 * AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))) / 5)
             tips: 
           Wavefront Occupancy:
-            value: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            value: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             peak: ($maxWavesPerCU * $numCU)
-            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / ($maxWavesPerCU
+            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / ($maxWavesPerCU
               * $numCU))))
             coll_level: SQ_LEVEL_WAVES
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx940/0300_mem_chart.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/0300_mem_chart.yaml
@@ -23,7 +23,7 @@ Panel Config:
           #TODO: double check wave_occupancy
           Wavefront Occupancy:
             #alias: wave_occ_
-            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / $numActiveCUs), 0)
+            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / $numActiveCUs), 0)
             coll_level: SQ_LEVEL_WAVES
             tips:
           Wave Life:
@@ -111,7 +111,7 @@ Panel Config:
           LDS Util:
             #alias: lds_util_
             value:
-              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
+              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))),
               0)
             tips:
           LDS Latency:

--- a/src/omniperf_soc/analysis_configs/gfx940/0600_shader-processor-input.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/0600_shader-processor-input.yaml
@@ -20,33 +20,33 @@ Panel Config:
           tips: Tips
         metric:
           Accelerator Utilization:
-            avg: AVG(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            min: MIN(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            max: MAX(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
+            avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            max: MAX(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             unit: Pct
             tips: 
           Scheduler-Pipe Utilization:
-            avg: AVG(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            min: MIN(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            max: MAX(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
+            avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
             unit: Pct
             tips: 
           Workgroup Manager Utilization:
-            avg: AVG(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            min: MIN(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            max: MAX(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
+            avg: AVG(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
             unit: Pct
             tips: 
           Shader Engine Utilization:
-            avg: AVG(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            min: MIN(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            max: MAX(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
+            avg: AVG(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            min: MIN(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            max: MAX(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
             unit: Pct
             tips: 
           SIMD Utilization:
-            avg: AVG(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Dispatched Workgroups:
@@ -91,77 +91,77 @@ Panel Config:
           tips: Tips
         metric:
           Not-scheduled Rate (Workgroup Manager):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Not-scheduled Rate (Scheduler-Pipe):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Scheduler-Pipe Stall Rate:
-            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
             unit: Pct
             tips: 
           Scratch Stall Rate:
-            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            min: MIN((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            max: MAX((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
+            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            min: MIN((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            max: MAX((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
             unit: Pct
             tips: 
           Insufficient SIMD Waveslots:
-            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD VGPRs:
-            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD SGPRs:
-            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU LDS:
-            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU Barriers:
-            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Workgroup Limit:
-            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Wavefront Limit:
-            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx940/0700_wavefront-launch.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/0700_wavefront-launch.yaml
@@ -98,9 +98,9 @@ Panel Config:
             unit: ns
             tips:
           Kernel Time (Cycles):
-            avg: AVG(GRBM_GUI_ACTIVE)
-            min: MIN(GRBM_GUI_ACTIVE)
-            max: MAX(GRBM_GUI_ACTIVE)
+            avg: AVG($GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN($GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX($GRBM_GUI_ACTIVE_PER_XCD)
             unit: Cycle
             tips:
           Instructions per wavefront:
@@ -134,9 +134,9 @@ Panel Config:
             unit: (Cycles + $normUnit)
             tips:
           Wavefront Occupancy:
-            avg: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            min: MIN((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            max: MAX((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            avg: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            min: MIN((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            max: MAX((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             coll_level: SQ_LEVEL_WAVES
             tips:

--- a/src/omniperf_soc/analysis_configs/gfx940/1100_compute-unit-compute-pipeline.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/1100_compute-unit-compute-pipeline.yaml
@@ -107,27 +107,27 @@ Panel Config:
             unit: Instr/cycle
             tips: 
           SALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VMEM Utilization:
-            avg: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           Branch Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Active Threads:
@@ -140,9 +140,9 @@ Panel Config:
             unit: Threads
             tips: 
           MFMA Utilization:
-            avg: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
-            min: MIN(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
-            max: MAX(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
+            avg: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
+            min: MIN(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
+            max: MAX(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips: 
           MFMA Instr Cycles:

--- a/src/omniperf_soc/analysis_configs/gfx940/1200_lds.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/1200_lds.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips:
           Access Rate:
-            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips:
           Theoretical Bandwidth (% of Peak):

--- a/src/omniperf_soc/analysis_configs/gfx940/1500_TA_and_TD.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/1500_TA_and_TD.yaml
@@ -20,27 +20,27 @@ Panel Config:
           tips: Tips
         metric:
           Address Processing Unit Busy:
-            avg: AVG(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data Stall:
-            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data-Processor → Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Total Instructions:
@@ -128,21 +128,21 @@ Panel Config:
           tips: Tips
         metric:
           Data-Return Busy:
-            avg: AVG(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Cache RAM → Data-Return Stall:
-            avg: AVG(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Workgroup manager → Data-Return Stall:
-            avg: AVG(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Coalescable Instructions:

--- a/src/omniperf_soc/analysis_configs/gfx940/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx940/1700_L2_cache.yaml
@@ -18,7 +18,7 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips:
           Bandwidth:

--- a/src/omniperf_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
@@ -84,36 +84,36 @@ Panel Config:
             pop: ((100 * $numActiveCUs) / $numCU)
             tips: 
           SALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           VALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           MFMA Utilization:
-            value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((GRBM_GUI_ACTIVE * $numCU)
+            value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD * $numCU)
               * 4)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((GRBM_GUI_ACTIVE * $numCU)
+            pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD * $numCU)
               * 4)))
             tips: 
           VMEM Utilization:
-            value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             peak: 100
-            pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             tips: 
           Branch Utilization:
-            value: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            value: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             peak: 100
-            pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             tips: 
           VALU Active Threads:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
@@ -130,10 +130,10 @@ Panel Config:
             pop: ((100 * AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))) / 5)
             tips: 
           Wavefront Occupancy:
-            value: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            value: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             peak: ($maxWavesPerCU * $numCU)
-            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / ($maxWavesPerCU
+            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / ($maxWavesPerCU
               * $numCU))))
             coll_level: SQ_LEVEL_WAVES
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx941/0300_mem_chart.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/0300_mem_chart.yaml
@@ -23,7 +23,7 @@ Panel Config:
           #TODO: double check wave_occupancy
           Wavefront Occupancy:
             #alias: wave_occ_
-            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / $numActiveCUs), 0)
+            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / $numActiveCUs), 0)
             coll_level: SQ_LEVEL_WAVES
             tips:
           Wave Life:
@@ -111,7 +111,7 @@ Panel Config:
           LDS Util:
             #alias: lds_util_
             value:
-              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
+              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))),
               0)
             tips:
           LDS Latency:

--- a/src/omniperf_soc/analysis_configs/gfx941/0600_shader-processor-input.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/0600_shader-processor-input.yaml
@@ -20,33 +20,33 @@ Panel Config:
           tips: Tips
         metric:
           Accelerator Utilization:
-            avg: AVG(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            min: MIN(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            max: MAX(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
+            avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            max: MAX(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             unit: Pct
             tips: 
           Scheduler-Pipe Utilization:
-            avg: AVG(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            min: MIN(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            max: MAX(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
+            avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
             unit: Pct
             tips: 
           Workgroup Manager Utilization:
-            avg: AVG(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            min: MIN(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            max: MAX(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
+            avg: AVG(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
             unit: Pct
             tips: 
           Shader Engine Utilization:
-            avg: AVG(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            min: MIN(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            max: MAX(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
+            avg: AVG(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            min: MIN(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            max: MAX(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
             unit: Pct
             tips: 
           SIMD Utilization:
-            avg: AVG(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Dispatched Workgroups:
@@ -91,77 +91,77 @@ Panel Config:
           tips: Tips
         metric:
           Not-scheduled Rate (Workgroup Manager):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Not-scheduled Rate (Scheduler-Pipe):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Scheduler-Pipe Stall Rate:
-            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
             unit: Pct
             tips: 
           Scratch Stall Rate:
-            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            min: MIN((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            max: MAX((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
+            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            min: MIN((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            max: MAX((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
             unit: Pct
             tips: 
           Insufficient SIMD Waveslots:
-            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD VGPRs:
-            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD SGPRs:
-            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU LDS:
-            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU Barriers:
-            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Workgroup Limit:
-            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Wavefront Limit:
-            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx941/0700_wavefront-launch.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/0700_wavefront-launch.yaml
@@ -98,9 +98,9 @@ Panel Config:
             unit: ns
             tips:
           Kernel Time (Cycles):
-            avg: AVG(GRBM_GUI_ACTIVE)
-            min: MIN(GRBM_GUI_ACTIVE)
-            max: MAX(GRBM_GUI_ACTIVE)
+            avg: AVG($GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN($GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX($GRBM_GUI_ACTIVE_PER_XCD)
             unit: Cycle
             tips:
           Instructions per wavefront:
@@ -134,9 +134,9 @@ Panel Config:
             unit: (Cycles + $normUnit)
             tips:
           Wavefront Occupancy:
-            avg: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            min: MIN((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            max: MAX((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            avg: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            min: MIN((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            max: MAX((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             coll_level: SQ_LEVEL_WAVES
             tips:

--- a/src/omniperf_soc/analysis_configs/gfx941/1100_compute-unit-compute-pipeline.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/1100_compute-unit-compute-pipeline.yaml
@@ -107,27 +107,27 @@ Panel Config:
             unit: Instr/cycle
             tips: 
           SALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VMEM Utilization:
-            avg: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           Branch Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Active Threads:
@@ -140,9 +140,9 @@ Panel Config:
             unit: Threads
             tips: 
           MFMA Utilization:
-            avg: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
-            min: MIN(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
-            max: MAX(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
+            avg: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
+            min: MIN(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
+            max: MAX(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips: 
           MFMA Instr Cycles:

--- a/src/omniperf_soc/analysis_configs/gfx941/1200_lds.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/1200_lds.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips:
           Access Rate:
-            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips:
           Theoretical Bandwidth (% of Peak):

--- a/src/omniperf_soc/analysis_configs/gfx941/1500_TA_and_TD.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/1500_TA_and_TD.yaml
@@ -20,27 +20,27 @@ Panel Config:
           tips: Tips
         metric:
           Address Processing Unit Busy:
-            avg: AVG(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data Stall:
-            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data-Processor → Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Total Instructions:
@@ -128,21 +128,21 @@ Panel Config:
           tips: Tips
         metric:
           Data-Return Busy:
-            avg: AVG(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Cache RAM → Data-Return Stall:
-            avg: AVG(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Workgroup manager → Data-Return Stall:
-            avg: AVG(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Coalescable Instructions:

--- a/src/omniperf_soc/analysis_configs/gfx941/1700_L2_cache.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx941/1700_L2_cache.yaml
@@ -18,7 +18,7 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * GRBM_GUI_ACTIVE)))
+            value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($L2Banks) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips:
           Bandwidth:

--- a/src/omniperf_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
@@ -84,36 +84,36 @@ Panel Config:
             pop: ((100 * $numActiveCUs) / $numCU)
             tips: 
           SALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           VALU Utilization:
-            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / (GRBM_GUI_ACTIVE * $numCU)))
+            pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             tips: 
           MFMA Utilization:
-            value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((GRBM_GUI_ACTIVE * $numCU)
+            value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD * $numCU)
               * 4)))
             unit: pct
             peak: 100
-            pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((GRBM_GUI_ACTIVE * $numCU)
+            pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD * $numCU)
               * 4)))
             tips: 
           VMEM Utilization:
-            value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             peak: 100
-            pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             tips: 
           Branch Utilization:
-            value: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            value: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             peak: 100
-            pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             tips: 
           VALU Active Threads:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
@@ -130,10 +130,10 @@ Panel Config:
             pop: ((100 * AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))) / 5)
             tips: 
           Wavefront Occupancy:
-            value: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            value: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             peak: ($maxWavesPerCU * $numCU)
-            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / ($maxWavesPerCU
+            pop: (100 * AVG(((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / ($maxWavesPerCU
               * $numCU))))
             coll_level: SQ_LEVEL_WAVES
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx942/0300_mem_chart.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/0300_mem_chart.yaml
@@ -23,7 +23,7 @@ Panel Config:
           #TODO: double check wave_occupancy
           Wavefront Occupancy:
             #alias: wave_occ_
-            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE) / $numActiveCUs), 0)
+            value: ROUND(AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD) / $numActiveCUs), 0)
             coll_level: SQ_LEVEL_WAVES
             tips:
           Wave Life:
@@ -111,7 +111,7 @@ Panel Config:
           LDS Util:
             #alias: lds_util_
             value:
-              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU))),
+              ROUND(AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))),
               0)
             tips:
           LDS Latency:

--- a/src/omniperf_soc/analysis_configs/gfx942/0600_shader-processor-input.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/0600_shader-processor-input.yaml
@@ -20,33 +20,33 @@ Panel Config:
           tips: Tips
         metric:
           Accelerator Utilization:
-            avg: AVG(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            min: MIN(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
-            max: MAX(100 * GRBM_GUI_ACTIVE / GRBM_COUNT)
+            avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
+            max: MAX(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             unit: Pct
             tips: 
           Scheduler-Pipe Utilization:
-            avg: AVG(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            min: MIN(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
-            max: MAX(100 * SPI_CSN_BUSY / (GRBM_GUI_ACTIVE * $numPipes * $numSE))
+            avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
+            max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $numPipes * $numSE))
             unit: Pct
             tips: 
           Workgroup Manager Utilization:
-            avg: AVG(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            min: MIN(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
-            max: MAX(100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE)
+            avg: AVG(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX(100 * $GRBM_SPI_BUSY_PER_XCD / $GRBM_GUI_ACTIVE_PER_XCD)
             unit: Pct
             tips: 
           Shader Engine Utilization:
-            avg: AVG(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            min: MIN(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
-            max: MAX(100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $numSE))
+            avg: AVG(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            min: MIN(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
+            max: MAX(100 * SQ_BUSY_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numSE))
             unit: Pct
             tips: 
           SIMD Utilization:
-            avg: AVG(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SQ_BUSY_CU_CYCLES / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Dispatched Workgroups:
@@ -91,77 +91,77 @@ Panel Config:
           tips: Tips
         metric:
           Not-scheduled Rate (Workgroup Manager):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Not-scheduled Rate (Scheduler-Pipe):
-            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
             unit: Pct
             tips: 
           Scheduler-Pipe Stall Rate:
-            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            avg: AVG((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            min: MIN((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
-            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY !=
+            max: MAX((((100 * SPI_RA_RES_STALL_CSN) / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None))
             unit: Pct
             tips: 
           Scratch Stall Rate:
-            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            min: MIN((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
-            max: MAX((100 * SPI_RA_TMP_STALL_CSN / (GRBM_SPI_BUSY * $numSE)) if (GRBM_SPI_BUSY != 0) else None)
+            avg: AVG((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            min: MIN((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
+            max: MAX((100 * SPI_RA_TMP_STALL_CSN / ($GRBM_SPI_BUSY_PER_XCD * $numSE)) if ($GRBM_SPI_BUSY_PER_XCD != 0) else None)
             unit: Pct
             tips: 
           Insufficient SIMD Waveslots:
-            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_WAVE_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD VGPRs:
-            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_VGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient SIMD SGPRs:
-            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(100 * SPI_RA_SGPR_SIMD_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU LDS:
-            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_LDS_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Insufficient CU Barriers:
-            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_BAR_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Workgroup Limit:
-            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_TGLIM_CU_FULL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 
           Reached CU Wavefront Limit:
-            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
-            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / (GRBM_GUI_ACTIVE * $numCU))
+            avg: AVG(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            min: MIN(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
+            max: MAX(400 * SPI_RA_WVLIM_STALL_CSN / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU))
             unit: Pct
             tips: 

--- a/src/omniperf_soc/analysis_configs/gfx942/0700_wavefront-launch.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/0700_wavefront-launch.yaml
@@ -98,9 +98,9 @@ Panel Config:
             unit: ns
             tips:
           Kernel Time (Cycles):
-            avg: AVG(GRBM_GUI_ACTIVE)
-            min: MIN(GRBM_GUI_ACTIVE)
-            max: MAX(GRBM_GUI_ACTIVE)
+            avg: AVG($GRBM_GUI_ACTIVE_PER_XCD)
+            min: MIN($GRBM_GUI_ACTIVE_PER_XCD)
+            max: MAX($GRBM_GUI_ACTIVE_PER_XCD)
             unit: Cycle
             tips:
           Instructions per wavefront:
@@ -134,9 +134,9 @@ Panel Config:
             unit: (Cycles + $normUnit)
             tips:
           Wavefront Occupancy:
-            avg: AVG((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            min: MIN((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
-            max: MAX((SQ_ACCUM_PREV_HIRES / GRBM_GUI_ACTIVE))
+            avg: AVG((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            min: MIN((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
+            max: MAX((SQ_ACCUM_PREV_HIRES / $GRBM_GUI_ACTIVE_PER_XCD))
             unit: Wavefronts
             coll_level: SQ_LEVEL_WAVES
             tips:

--- a/src/omniperf_soc/analysis_configs/gfx942/1100_compute-unit-compute-pipeline.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1100_compute-unit-compute-pipeline.yaml
@@ -107,27 +107,27 @@ Panel Config:
             unit: Instr/cycle
             tips: 
           SALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_SCA) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VMEM Utilization:
-            avg: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           Branch Utilization:
-            avg: AVG((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
-            min: MIN((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
-            max: MAX((((100 * SQ_ACTIVE_INST_MISC) / GRBM_GUI_ACTIVE) / $numCU))
+            avg: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            min: MIN((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
+            max: MAX((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $numCU))
             unit: pct
             tips: 
           VALU Active Threads:
@@ -140,9 +140,9 @@ Panel Config:
             unit: Threads
             tips: 
           MFMA Utilization:
-            avg: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
-            min: MIN(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
-            max: MAX(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * GRBM_GUI_ACTIVE)))
+            avg: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
+            min: MIN(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
+            max: MAX(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / ((4 * $numCU) * $GRBM_GUI_ACTIVE_PER_XCD)))
             unit: pct
             tips: 
           MFMA Instr Cycles:

--- a/src/omniperf_soc/analysis_configs/gfx942/1200_lds.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1200_lds.yaml
@@ -18,11 +18,11 @@ Panel Config:
           tips: Tips
         metric:
           Utilization:
-            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips:
           Access Rate:
-            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / (GRBM_GUI_ACTIVE * $numCU)))
+            value: AVG(((200 * SQ_ACTIVE_INST_LDS) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: Pct of Peak
             tips:
           Theoretical Bandwidth (% of Peak):

--- a/src/omniperf_soc/analysis_configs/gfx942/1500_TA_and_TD.yaml
+++ b/src/omniperf_soc/analysis_configs/gfx942/1500_TA_and_TD.yaml
@@ -20,27 +20,27 @@ Panel Config:
           tips: Tips
         metric:
           Address Processing Unit Busy:
-            avg: AVG(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_TA_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data Stall:
-            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_DATA_STALLED_BY_TC_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Data-Processor → Address Stall:
-            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Total Instructions:
@@ -128,21 +128,21 @@ Panel Config:
           tips: Tips
         metric:
           Data-Return Busy:
-            avg: AVG(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TD_BUSY_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Cache RAM → Data-Return Stall:
-            avg: AVG(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_TC_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Workgroup manager → Data-Return Stall:
-            avg: AVG(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            min: MIN(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
-            max: MAX(((100 * TD_SPI_STALL_sum) / (GRBM_GUI_ACTIVE * $numCU)))
+            avg: AVG(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            min: MIN(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
+            max: MAX(((100 * TD_SPI_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $numCU)))
             unit: pct
             tips: 
           Coalescable Instructions:

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -80,6 +80,9 @@ build_in_vars = {
               0) / $maxWavesPerCU) * 8) + MIN(MOD(ROUND(AVG(((4 * SQ_BUSY_CU_CYCLES) \
               / GRBM_GUI_ACTIVE)), 0), $maxWavesPerCU), 8)), $numCU))",
     "kernelBusyCycles": "ROUND(AVG((((End_Timestamp - Start_Timestamp) / 1000) * $sclk)), 0)",
+    "GRBM_GUI_ACTIVE_PER_XCD": "(GRBM_GUI_ACTIVE / $XCDs)",
+    "GRBM_COUNT_PER_XCD": "(GRBM_COUNT / $XCDs)",
+    "GRBM_SPI_BUSY_PER_XCD" : "(GRBM_SPI_BUSY / $XCDs)"
 }
 
 supported_call = {
@@ -693,6 +696,7 @@ def eval_metric(dfs, dfs_type, sys_info, soc_spec, raw_pmc_df, debug):
     ammolite__freq = sys_info.cur_sclk  # todo: check do we still need it
     ammolite__mclk = sys_info.cur_mclk
     ammolite__sclk = sys_info.sclk
+    ammolite__XCDs = sys_info.XCDs
     ammolite__maxWavesPerCU = sys_info.maxWavesPerCU
     ammolite__hbmBW = sys_info.hbmBW
     ammolite__totalL2Banks = calc_builtin_var("$totalL2Banks", sys_info)
@@ -714,6 +718,9 @@ def eval_metric(dfs, dfs_type, sys_info, soc_spec, raw_pmc_df, debug):
 
     ammolite__numActiveCUs = ammolite__build_in["numActiveCUs"]
     ammolite__kernelBusyCycles = ammolite__build_in["kernelBusyCycles"]
+    ammolite__GRBM_GUI_ACTIVE_PER_XCD = ammolite__build_in["GRBM_GUI_ACTIVE_PER_XCD"]
+    ammolite__GRBM_COUNT_PER_XCD = ammolite__build_in["GRBM_COUNT_PER_XCD"]
+    ammolite__GRBM_SPI_BUSY_PER_XCD = ammolite__build_in["GRBM_SPI_BUSY_PER_XCD"]
 
     # Hmmm... apply + lambda should just work
     # df['Value'] = df['Value'].apply(lambda s: eval(compile(str(s), '<string>', 'eval')))
@@ -1004,6 +1011,7 @@ def correct_sys_info(df, specs_correction):
         "hbmBW": "hbmBW",
         "compute_partition": "compute_partition",
         "memory_partition": "memory_partition",
+        "XCDs": "XCDs"
     }
 
     # todo: more err checking for string specs_correction

--- a/src/utils/specs.py
+++ b/src/utils/specs.py
@@ -106,7 +106,7 @@ class MachineSpecs:
             hbmBW:              {self.hbmBW} MB/s
             compute_partition:  {self.compute_partition}
             memory_partition:   {self.memory_partition}
-            XCCs:               {self.XCCs}
+            XCDs:               {self.XCDs}
         """
         )
 

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -300,7 +300,7 @@ def gen_sysinfo(workload_name, workload_dir, ip_blocks, app_cmd, skip_roof, roof
     header += "host_name,host_cpu,sbios,host_distro,host_kernel,host_rocmver,date,"
     header += "gpu_soc,vbios,numSE,numCU,numSIMD,waveSize,maxWavesPerCU,maxWorkgroupSize,"
     header += "L1,L2,sclk,mclk,cur_sclk,cur_mclk,L2Banks,totalL2Banks,LDSBanks,name,numSQC,numPipes,"
-    header += "hbmBW,compute_partition,memory_partition,"
+    header += "hbmBW,compute_partition,memory_partition,XCDs,"
     header += "ip_blocks\n"
     sysinfo.write(header)
 
@@ -350,6 +350,7 @@ def gen_sysinfo(workload_name, workload_dir, ip_blocks, app_cmd, skip_roof, roof
         mspec.hbmBW,
         mspec.compute_partition,
         mspec.memory_partition,
+        mspec.XCDs,
     ]
 
     blocks = []


### PR DESCRIPTION
Solves https://github.com/AMDResearch/omniperf/issues/248

Currently, on MI300, GRBM counters are being summed over XCDs
	- This results in many utilizations, etc., which rely on these being clock timers being incorrectly calculated (because you have ~ # XCDs * clocks)

We correct this issue by:
	- implementing a new function that maps the compute partition + arch to an XCD number based on the whitepaper
	- defining GRBM_GUI_ACTIVE_PER_XCD = average of GRBM_GUI_ACTIVE over all XCDs (and similar variables for other related counters)

For consistency, we use this in all the yaml files regardless of the arch, but on any non-MI300 arch, we should have only 1XCD, i.e., they're identical

When rocprof corrects this behavior, we can simply omit the division.