### PR TITLE
Force encoding before Omniperf execution

### DIFF
--- a/src/omniperf
+++ b/src/omniperf
@@ -25,13 +25,19 @@
 ##############################################################################el
 
 import sys
+import locale
+import logging
+from utils.utils import error
 from omniperf_base import Omniperf
 
 def main():
+    try:
+        locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+    except locale.Error as e:
+        logging.warning("Please ensure that the 'en_US.UTF-8' locale is available on your system.")
+        error(f"Error setting locale: {e}")
 
     omniperf = Omniperf()
-    omniperf.parse_args() #TODO: We already do this in the __init__ for Omniperf(). Change that?
-
     mode = omniperf.get_mode()
 
     # major omniperf execution modes

--- a/src/utils/specs.py
+++ b/src/utils/specs.py
@@ -36,9 +36,8 @@ import pandas as pd
 
 from datetime import datetime
 from math import ceil
-from dataclasses import dataclass, field, asdict, fields
+from dataclasses import dataclass, field, fields
 from pathlib import Path as path
-from textwrap import dedent
 from utils.utils import error, get_hbm_stack_num, get_version
 from utils.tty import get_table_string
 

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -32,8 +32,6 @@ import subprocess
 import shutil
 import pandas as pd
 import glob
-from utils import specs
-from datetime import datetime
 from pathlib import Path as path
 import config
 
@@ -324,6 +322,8 @@ def gen_sysinfo(
 
 
 def detect_roofline(mspec):
+    from utils import specs
+
     rocm_ver = mspec.rocm_version[:1]
 
     os_release = path("/etc/os-release").read_text()


### PR DESCRIPTION
Closes #19.

I read some warnings about the module not being thread-safe.

> This sets the locale for all categories to the user’s default setting (typically specified in the LANG environment variable). If the locale is not changed thereafter, using multithreading should not cause problems.

Since we always want this encoding I think it should be okay.