### PR TITLE
Minor enhancements for log output 

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -51,6 +51,15 @@ class ColoredFormatter(logging.Formatter):
         return logging.Formatter.format(self, record)
 
 
+class PlainFormatter(logging.Formatter):
+    def format(self, record):
+        if record.levelno == logging.ERROR:
+            self._style._fmt = "%(levelname)s: %(message)s"
+        else:
+            self._style._fmt = "%(message)s"
+        return logging.Formatter.format(self, record)
+
+
 # Setup console handler - provided as separate function to be called
 # prior to argument parsing
 def setup_console_handler():
@@ -61,9 +70,9 @@ def setup_console_handler():
             color = True
 
     if color:
-        formatter = ColoredFormatter("%(levelname)s %(message)s")
+        formatter = ColoredFormatter("%(levelname)16s %(message)s")
     else:
-        formatter = logging.Formatter("%(message)s")
+        formatter = PlainFormatter()
 
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(formatter)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -38,6 +38,7 @@ COLORS = {
     "DEBUG": BLUE,
     "CRITICAL": YELLOW,
     "ERROR": RED,
+    "TRACE": MAGENTA,
 }
 
 

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -51,9 +51,9 @@ def demarcate(function):
 
 def console_error(*argv, exit=True):
     if len(argv) > 1:
-        logging.error("ERROR: " + f"[{argv[0]}] {argv[1]}")
+        logging.error(f"[{argv[0]}] {argv[1]}")
     else:
-        logging.error("ERROR: " + f"{argv[0]}")
+        logging.error(f"{argv[0]}")
     if exit:
         sys.exit(1)
 


### PR DESCRIPTION
1. make ERROR output consistent when color is enabled/disabled
2. assign color to custom TRACE level
3. justify levelname output when color is enabled

This should give users a reasonable experience if they want to enable color via `OMNIPERF_COLOR=1`.  We can revisit later what the preferred default mode should be.

