### PR TITLE
Fix the `MOD_INSTALL_PATH` in docs

### DIFF
--- a/docs/install/core-install.rst
+++ b/docs/install/core-install.rst
@@ -142,7 +142,7 @@ Install from source
          cd build
          cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/{{ config.version }} \
                  -DPYTHON_DEPS=${INSTALL_DIR}/python-libs \
-                 -DMOD_INSTALL_PATH=${INSTALL_DIR}/modulefiles ..
+                 -DMOD_INSTALL_PATH=${INSTALL_DIR}/modulefiles/omniperf ..
 
          # install
          make install


### PR DESCRIPTION
The current install documentation provides an incorrect `MOD_INSTALL_PATH` :
https://github.com/ROCm/omniperf/blob/ef16df71be0f149a46396c17d1a4068220b72da6/docs/install/core-install.rst?plain=1#L143-L145

This path is incorrect because later in the documentation under "Execution using modulefiles", we provide user with instructions that assume an omniperf suffix on module path
https://github.com/ROCm/omniperf/blob/ef16df71be0f149a46396c17d1a4068220b72da6/docs/install/core-install.rst?plain=1#L179-L180