### PR TITLE
Rollback Grafana for Compatibility with deprecated plugin

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -18,13 +18,11 @@ ENV NODE_VERSION 20.12.2
 ADD plugins/omniperf_plugin /var/lib/grafana/plugins/omniperf_plugin
 
 # Install Grafana and MongoDB Community Edition
+# Note: Grafana install is stubbed to 10.4.3
 RUN apt-get update && \
-    apt-get install -y apt-transport-https software-properties-common wget && \
-    mkdir -p /etc/apt/keyrings/ && \
-    wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null && \
-    echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | tee -a /etc/apt/sources.list.d/grafana.list && \
-    apt-get update && \
-    apt-get install -y grafana && \
+    apt-get install -y adduser libfontconfig1 musl wget && \
+    wget -q https://dl.grafana.com/enterprise/release/grafana-enterprise_10.4.3_amd64.deb && \
+    dpkg -i grafana-enterprise_10.4.3_amd64.deb && \
     apt-get install -y gnupg curl && \
     curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg  --dearmor && \
     echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list && \


### PR DESCRIPTION
**Filing PR in response to #416** 

This PR is a short-term solution to meet immediate requirements from El Capitan to get started with Grafana. I rolled back the Grafana version that's downloaded in the Dockerfile so that the Angular-based Omniperf plugin can still be used.

We still need to implement a long-term solution, which could be migrating our existing deprecated Angular plugin to React. More info on how to do that is given in Grafana release notes:
https://grafana.com/blog/2024/03/11/removal-of-angularjs-support-in-grafana-what-you-need-to-know/

Waiting to discuss roadmap with @nartmada and team to determine a preferred long-term fix.