### PR TITLE
Add the ability to determine GPU model from Chip ID

### DIFF
--- a/src/omniperf_soc/soc_base.py
+++ b/src/omniperf_soc/soc_base.py
@@ -180,7 +180,7 @@ class OmniSoC_Base:
         self._mspec.gpu_model = list(SUPPORTED_ARCHS[self._mspec.gpu_arch].keys())[
             0
         ].upper()
-        if self._mspec.gpu_model == "MI300": 
+        if self._mspec.gpu_model == "MI300":
             # Use Chip ID to distinguish MI300 gpu model using the built-in dictionary
             if self._mspec.chip_id in MI300_CHIP_IDS:
                 self._mspec.chip_id = MI300_CHIP_IDS[self._mspec.chip_id]


### PR DESCRIPTION
Add the ability to determine GPU model from Chip ID to distinguish MI300 systems by using a built-in dictionary.
The built-in dictionary should be populated to include known chip id to system pairs.