### PR TITLE
Automate release notes

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -57,5 +57,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && github.repository == 'ROCm/omniperf'
         with:
           fail_on_unmatched: True
+          generate_release_notes: True
+          draft: False # toggle for debugging
           files: |
             build/omniperf-${{github.ref_name}}.tar.gz
+          name: ${{ env.RELEASE_NAME }}
+


### PR DESCRIPTION
This pull request automates the creation of release notes via the [gh-release](https://github.com/marketplace/actions/gh-release) action used in the existing packaging.yml workflow. Additionally, a "smart" release name will be assigned following "Omniperf VERSION for rocm-x.x.x", i.e.
![image](https://github.com/user-attachments/assets/f900ae54-c490-44a5-9af7-9f2f4e5a021c)

CC: @njobypet 