### PR TITLE
Documented Docker container OpenSSL abilities being affected by Host network proxy services

### DIFF
--- a/docs/install/grafana-setup.rst
+++ b/docs/install/grafana-setup.rst
@@ -79,6 +79,14 @@ directory to begin.
    $ sudo docker-compose build
    $ sudo docker-compose up -d
 
+.. note::
+   In the event docker container build fails to verify certificates, try to disable 
+   network proxy services as a first step.
+   Network proxy services running on the host can significantly interfere with 
+   OpenSSL's ability to retrieve a proper certificate chain when accessing websites 
+   from within Docker containers.
+   
+
 The TCP ports for Grafana (``4000``) and MongoDB (``27017``) in the Docker
 container are mapped to ``14000`` and ``27018``, respectively, on the host side.
 

--- a/docs/install/grafana-setup.rst
+++ b/docs/install/grafana-setup.rst
@@ -80,12 +80,11 @@ directory to begin.
    $ sudo docker-compose up -d
 
 .. note::
-   In the event docker container build fails to verify certificates, try to disable 
-   network proxy services as a first step.
-   Network proxy services running on the host can significantly interfere with 
-   OpenSSL's ability to retrieve a proper certificate chain when accessing websites 
-   from within Docker containers.
-   
+
+   To troubleshoot Docker container build failures related to certificate verification, try 
+   disabling any network proxy services on the host system. These proxy services can interfere 
+   with OpenSSL's ability to retrieve a correct certificate chain when the container accesses 
+   external websites.
 
 The TCP ports for Grafana (``4000``) and MongoDB (``27017``) in the Docker
 container are mapped to ``14000`` and ``27018``, respectively, on the host side.


### PR DESCRIPTION
Host network proxy services cause network certificates verification problem during Docker container build stage of Grafana server setup.