### PR TITLE
Skip output lines that have UTF8 decoding error 

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -205,7 +205,7 @@ def capture_subprocess_output(subprocess_args, new_env=None, profileMode=False):
     buf = io.StringIO()
 
     def handle_output(stream, mask):
-        try:   
+        try:
             # Because the process' output is line buffered, there's only ever one
             # line to read when this function is called
             line = stream.readline()

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -205,14 +205,17 @@ def capture_subprocess_output(subprocess_args, new_env=None, profileMode=False):
     buf = io.StringIO()
 
     def handle_output(stream, mask):
-        # Because the process' output is line buffered, there's only ever one
-        # line to read when this function is called
-        line = stream.readline()
-        buf.write(line)
-        if profileMode:
-            console_log(rocprof_cmd, line.strip(), indent_level=1)
-        else:
-            console_log(line.strip())
+        try:   
+            # Because the process' output is line buffered, there's only ever one
+            # line to read when this function is called
+            line = stream.readline()
+            buf.write(line)
+            if profileMode:
+                console_log(rocprof_cmd, line.strip(), indent_level=1)
+            else:
+                console_log(line.strip())
+        except UnicodeDecodeError as e:
+            console_log(str(e), indent_level=1)
 
     # Register callback for an "available for read" event from subprocess' stdout stream
     selector = selectors.DefaultSelector()

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -214,8 +214,9 @@ def capture_subprocess_output(subprocess_args, new_env=None, profileMode=False):
                 console_log(rocprof_cmd, line.strip(), indent_level=1)
             else:
                 console_log(line.strip())
-        except UnicodeDecodeError as e:
-            console_log(str(e), indent_level=1)
+        except UnicodeDecodeError:
+            # Skip this line
+            pass
 
     # Register callback for an "available for read" event from subprocess' stdout stream
     selector = selectors.DefaultSelector()


### PR DESCRIPTION
Omniperf assumes the output from rocprof is always UTF-8. But there is no guarantee that the user's code will always output UTF-8.

A customer was running Tensorflow and for whatever reason it output a non-UTF-8 character and crashed Omniperf.

Wrap existing code in a try/except block to catch UnicodeDecodeError so the line is skipped and profiling can continue.