### PR TITLE
Use MI300 chip_id instead of model to detect XCD count

### DIFF
--- a/src/omniperf_soc/soc_base.py
+++ b/src/omniperf_soc/soc_base.py
@@ -187,7 +187,7 @@ class OmniSoC_Base:
                 self._mspec.chip_id = MI300_CHIP_IDS[self._mspec.chip_id]
 
         self._mspec.num_xcd = str(
-            total_xcds(self._mspec.gpu_model, self._mspec.compute_partition)
+            total_xcds(self._mspec.chip_id, self._mspec.compute_partition)
         )
 
     @demarcate


### PR DESCRIPTION
In a previous change we began using "MI300" for gpu_model instead of the full "MI300X_A0" or "MI300X_A1", etc.

The XCD detection code was receiving gpu_model and expecting the full name, causing the XCD count = 1 and several metrics to be off by a factor of 8 (e.g. VALU utilization, wavefront occupancy).

Passing chip_id instead of gpu_model fixes the issue. 