### PR TITLE
Add broken mclk workaround for all arch

### DIFF
--- a/src/omniperf_soc/soc_gfx908.py
+++ b/src/omniperf_soc/soc_gfx908.py
@@ -63,7 +63,7 @@ class gfx908_soc(OmniSoC_Base):
         self._mspec.lds_banks_per_cu = 32
         self._mspec.pipes_per_gpu = 4
         # --showmclkrange is broken in Mi100, hardcode freq
-        if self._mspec.gpu_model == "MI300":
+        if self._mspec.gpu_model == "MI100":
             if self._mspec.max_mclk == None or self._mspec.cur_mclk == None:
                 self._mspec.max_mclk = 1200
                 self._mspec.cur_mclk = 1200

--- a/src/omniperf_soc/soc_gfx908.py
+++ b/src/omniperf_soc/soc_gfx908.py
@@ -63,8 +63,10 @@ class gfx908_soc(OmniSoC_Base):
         self._mspec.lds_banks_per_cu = 32
         self._mspec.pipes_per_gpu = 4
         # --showmclkrange is broken in Mi100, hardcode freq
-        self._mspec.max_mclk = 1200
-        self._mspec.cur_mclk = 1200
+        if self._mspec.gpu_model == "MI300":
+            if self._mspec.max_mclk == None or self._mspec.cur_mclk == None:
+                self._mspec.max_mclk = 1200
+                self._mspec.cur_mclk = 1200
 
     @demarcate
     def get_profiler_options(self):

--- a/src/omniperf_soc/soc_gfx90a.py
+++ b/src/omniperf_soc/soc_gfx90a.py
@@ -71,6 +71,13 @@ class gfx90a_soc(OmniSoC_Base):
         )
         self.roofline_obj = Roofline(args, self._mspec)
 
+        # Workaround for broken --showmclkrange
+        # MI210/MI250/MI250X have 1600MHz mclk
+        if self._mspec.gpu_model == "MI200":
+            if self._mspec.max_mclk == None or self._mspec.cur_mclk == None:
+                self._mspec.max_mclk = 1600
+                self._mspec.cur_mclk = 1600
+
         # Set arch specific specs
         self._mspec._l2_banks = 32
         self._mspec.lds_banks_per_cu = 32

--- a/src/omniperf_soc/soc_gfx942.py
+++ b/src/omniperf_soc/soc_gfx942.py
@@ -69,10 +69,12 @@ class gfx942_soc(OmniSoC_Base):
         )
         # self.roofline_obj = Roofline(args, self._mspec)
 
-        # --showmclkrange is broken in MI308X, hardcode freq
-        if self._mspec.gpu_model == "MI308X":
-            self._mspec.max_mclk = 1300
-            self._mspec.cur_mclk = 1300
+        # Workaround for broken --showmclkrange
+        # MI300X/MI300A/MI308X have 1300MHz mclk
+        if self._mspec.gpu_model == "MI300":
+            if self._mspec.max_mclk == None or self._mspec.cur_mclk == None:
+                self._mspec.max_mclk = 1300
+                self._mspec.cur_mclk = 1300
 
         # Set arch specific specs
         self._mspec._l2_banks = 16


### PR DESCRIPTION
Some time ago there was a rocm-smi version that failed to report mclk frequencies, causing omniperf to crash. And in the MI100 case, mclk has never worked.

People are still running into these issues often enough that it makes sense to add the workaround into Omniperf.

Tested on MI100/MI210/MI300X.