### PR TITLE
Fix PoP of VALU Active Threads with wave_size

### DIFF
--- a/src/rocprof_compute_soc/analysis_configs/gfx906/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx906/0200_system-speed-of-light.yaml
@@ -102,9 +102,8 @@ Panel Config:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
               != 0) else None))
             unit: Threads
-            peak: 64
-            pop: (AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
-              != 0) else None)) * 1.5625)
+            peak: $wave_size
+            pop: (100 * AVG((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU / $wave_size) if (SQ_ACTIVE_INST_VALU != 0) else None))
             tips: 
           IPC:
             value: AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/0200_system-speed-of-light.yaml
@@ -102,9 +102,8 @@ Panel Config:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
               != 0) else None))
             unit: Threads
-            peak: 64
-            pop: (AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
-              != 0) else None)) * 1.5625)
+            peak: $wave_size
+            pop: (100 * AVG((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU / $wave_size) if (SQ_ACTIVE_INST_VALU != 0) else None))
             tips: 
           IPC:
             value: AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
@@ -119,9 +119,8 @@ Panel Config:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
               != 0) else None))
             unit: Threads
-            peak: 64
-            pop: (AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
-              != 0) else None)) * 1.5625)
+            peak: $wave_size
+            pop: (100 * AVG((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU / $wave_size) if (SQ_ACTIVE_INST_VALU != 0) else None))
             tips: 
           IPC:
             value: AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
@@ -119,9 +119,8 @@ Panel Config:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
               != 0) else None))
             unit: Threads
-            peak: 64
-            pop: (AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
-              != 0) else None)) * 1.5625)
+            peak: $wave_size
+            pop: (100 * AVG((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU / $wave_size) if (SQ_ACTIVE_INST_VALU != 0) else None))
             tips: 
           IPC:
             value: AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
@@ -119,9 +119,8 @@ Panel Config:
             value: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
               != 0) else None))
             unit: Threads
-            peak: 64
-            pop: (AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
-              != 0) else None)) * 1.5625)
+            peak: $wave_size
+            pop: (100 * AVG((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU / $wave_size) if (SQ_ACTIVE_INST_VALU != 0) else None))
             tips: 
           IPC:
             value: AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -698,6 +698,7 @@ def eval_metric(dfs, dfs_type, sys_info, raw_pmc_df, debug):
     ammolite__hbm_bw = sys_info.hbm_bw
     ammolite__total_l2_chan = calc_builtin_var("$total_l2_chan", sys_info)
     ammolite__num_xcd = sys_info.num_xcd
+    ammolite__wave_size = sys_info.wave_size
 
     # TODO: fix all $normUnit in Unit column or title
 


### PR DESCRIPTION
The proper way to fix https://github.com/ROCm/rocprofiler-compute/pull/451.
@skyreflectedinmirrors 