### PR TITLE
Fix versions in changelog heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,37 +2,37 @@
 
 Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/).
 
-## Omniperf 2.1.0 for ROCm 6.2.2
+## Omniperf 2.0.1 for ROCm 6.2.1
 
-### Changes
+### Changed
 
-  * enable rocprofv1 for MI300 hardware (#391)
-  * refactoring and updating documemtation (#362, #394, #398, #414, #420)
-  * branch renaming and workflow updates (#389, #404, #409)
-  * bug fix for analysis output
-  * add dependency checks on application launch (#393)
-  * patch for profiling multi-process/multi-GPU applications (#376, #396)
-  * packaging updates (#386)
-  * rename CHANGES to CHANGELOG.md (#410)
-  * rollback Grafana version in Dockerfile for Angular plugin compatibility (#416)
-  * enable CI triggers for Azure CI (#426)
-  * add GPU model distinction for MI300 systems (#423)
-  * new MAINTAINERS.md guide for omniperf publishing procedures (#402)
+* enable rocprofv1 for MI300 hardware (#391)
+* refactoring and updating documemtation (#362, #394, #398, #414, #420)
+* branch renaming and workflow updates (#389, #404, #409)
+* bug fix for analysis output
+* add dependency checks on application launch (#393)
+* patch for profiling multi-process/multi-GPU applications (#376, #396)
+* packaging updates (#386)
+* rename CHANGES to CHANGELOG.md (#410)
+* rollback Grafana version in Dockerfile for Angular plugin compatibility (#416)
+* enable CI triggers for Azure CI (#426)
+* add GPU model distinction for MI300 systems (#423)
+* new MAINTAINERS.md guide for omniperf publishing procedures (#402)
 
-### Optimizations
+### Optimized
 
-  * reduced running time of Omniperf when profiling (#384) 
-  * console logging improvements
+* reduced running time of Omniperf when profiling (#384) 
+* console logging improvements
 
 ## Omniperf 2.0.1 for ROCm 6.2.0
 
-### Changes
+### Added
 
   * new option to force hardware target via `OMNIPERF_ARCH_OVERRIDE` global (#370)
   * CI/CD support for MI300 hardware (#373)
   * support for MI308X hardware (#375)
 
-### Optimizations
+### Optimized
 
   * cmake build improvements (#374)
 


### PR DESCRIPTION
Change Omniperf version in changelog from `2.1.0` to `2.0.1` to reflect version string in actual distributed package. Associated ROCm release should be `6.2.1`, not `6.2.2`.

Also includes super minor updates to subheadings to conform to updated internal style guide.