### PR TITLE
External CI: rename pipeline to rocprofiler-compute

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -43,4 +43,4 @@ pr:
   drafts: false
 
 jobs:
-  - template: ${{ variables.CI_COMPONENT_PATH }}/omniperf.yml@pipelines_repo
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocprofiler-compute.yml@pipelines_repo


### PR DESCRIPTION
Renames external Azure CI pipeline file to rocprofiler-compute.