### PR TITLE
Modify numpy version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ astunparse==1.6.2
 colorlover
 dash>=1.12.0
 matplotlib
-numpy<2,>=1.17.5
+numpy>=1.17.5
 pandas>=1.4.3
 pymongo
 pyyaml


### PR DESCRIPTION
Removing numpy requirements of <2.
Checks are failing if version too high and no need for lower version.


