### PR TITLE
Fix crash when loading web UI roofline for gfx942

### DIFF
--- a/src/rocprof_compute_soc/soc_gfx940.py
+++ b/src/rocprof_compute_soc/soc_gfx940.py
@@ -109,4 +109,6 @@ class gfx940_soc(OmniSoC_Base):
         super().analysis_setup()
         # configure roofline for analysis
         if roofline_parameters:
-            self.roofline_obj = Roofline(self.get_args(), self._mspec, roofline_parameters)
+            self.roofline_obj = Roofline(
+                self.get_args(), self._mspec, roofline_parameters
+            )

--- a/src/rocprof_compute_soc/soc_gfx940.py
+++ b/src/rocprof_compute_soc/soc_gfx940.py
@@ -109,4 +109,4 @@ class gfx940_soc(OmniSoC_Base):
         super().analysis_setup()
         # configure roofline for analysis
         if roofline_parameters:
-            self.roofline_obj = Roofline(self.get_args(), roofline_parameters)
+            self.roofline_obj = Roofline(self.get_args(), self._mspec, roofline_parameters)

--- a/src/rocprof_compute_soc/soc_gfx941.py
+++ b/src/rocprof_compute_soc/soc_gfx941.py
@@ -109,4 +109,6 @@ class gfx941_soc(OmniSoC_Base):
         super().analysis_setup()
         # configure roofline for analysis
         if roofline_parameters:
-            self.roofline_obj = Roofline(self.get_args(), self._mspec, roofline_parameters)
+            self.roofline_obj = Roofline(
+                self.get_args(), self._mspec, roofline_parameters
+            )

--- a/src/rocprof_compute_soc/soc_gfx941.py
+++ b/src/rocprof_compute_soc/soc_gfx941.py
@@ -109,4 +109,4 @@ class gfx941_soc(OmniSoC_Base):
         super().analysis_setup()
         # configure roofline for analysis
         if roofline_parameters:
-            self.roofline_obj = Roofline(self.get_args(), roofline_parameters)
+            self.roofline_obj = Roofline(self.get_args(), self._mspec, roofline_parameters)

--- a/src/rocprof_compute_soc/soc_gfx942.py
+++ b/src/rocprof_compute_soc/soc_gfx942.py
@@ -114,4 +114,6 @@ class gfx942_soc(OmniSoC_Base):
         super().analysis_setup()
         # configure roofline for analysis
         if roofline_parameters:
-            self.roofline_obj = Roofline(self.get_args(), self._mspec, roofline_parameters)
+            self.roofline_obj = Roofline(
+                self.get_args(), self._mspec, roofline_parameters
+            )

--- a/src/rocprof_compute_soc/soc_gfx942.py
+++ b/src/rocprof_compute_soc/soc_gfx942.py
@@ -114,4 +114,4 @@ class gfx942_soc(OmniSoC_Base):
         super().analysis_setup()
         # configure roofline for analysis
         if roofline_parameters:
-            self.roofline_obj = Roofline(self.get_args(), roofline_parameters)
+            self.roofline_obj = Roofline(self.get_args(), self._mspec, roofline_parameters)


### PR DESCRIPTION
An exception was thrown when loading the roofline chart in the Web UI for MI300.

Missing parameter when calling Roofline constructor, which caused the 3rd parameter to use a default value of None, resulting in an exception later in the code.