### PR TITLE
Update CHANGELOG for 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/).
 
+## Omniperf 3.0.0 for ROCm 6.3.0
+
+### Changed
+
+* Renamed Omniperf to ROCm Compute Profiler
+
 ## Omniperf 2.0.1 for ROCm 6.2.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/).
 
-## Omniperf 3.0.0 for ROCm 6.3.0
+## ROCm Compute Profiler 3.0.0 for ROCm 6.3.0
 
 ### Changed
 


### PR DESCRIPTION
Update CHANGELOG with version number and summary of single commit under 'changed' category.
Workflow was not able to capture the commit to the log because of the rebranding itself, needs manual push this time.
Note- VERSION and README have been changed to the correct 3.0.0 version from within the rebranding commit itself.