### PR TITLE
Fix ctest failure in mainline due to missing rebranding patch

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,12 +126,12 @@ def check_csv_files(output_dir, num_devices, num_kernels):
     return file_dict
 
 
-def launch_omniperf(config, options, workload_dir, check_success=True):
-    """Launch Omniperf with command-line optoins
+def launch_rocprof_compute(config, options, workload_dir, check_success=True):
+    """Launch ROCm Compute Profiler with command-line optoins
 
     Args:
         config (list): runtime configuration settings
-        options (list): command line options to provide to omniperf
+        options (list): command line options to provide to rocprofiler-compute
         workload_dir (string): desired output directory
         check_success (bool, optional): Whether to verify successful exit condition. Defaults to True.
 


### PR DESCRIPTION
Addressing ctest failure in mainline: renaming omniperf to rocprof_compute in test_util.py