### PR TITLE
fix for crash of timestamp of part 1 for rocprofv3

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -623,30 +623,37 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
             counter_info_csvs = glob.glob(
                 workload_dir + "/out/pmc_1/*/*_counter_collection.csv"
             )
+            
+            existing_counter_files_csv = [d for d in counter_info_csvs if os.path.isfile(d)]
+            
+            if len(existing_counter_files_csv) > 0:
+                for counter_file in existing_counter_files_csv:
+                    current_dir = os.path.dirname(counter_file)
+                    agent_info_filepath = os.path.join(
+                        current_dir,
+                        os.path.basename(counter_file).replace(
+                            "_counter_collection", "_agent_info"
+                        ),
+                    )
+                    if not os.path.isfile(agent_info_filepath):
+                        raise ValueError(
+                            '{} has no coresponding "agent info" file'.format(counter_file)
+                        )
 
-            for counter_file in counter_info_csvs:
-                current_dir = os.path.dirname(counter_file)
-                agent_info_filepath = os.path.join(
-                    current_dir,
-                    os.path.basename(counter_file).replace(
-                        "_counter_collection", "_agent_info"
-                    ),
-                )
-                if not os.path.isfile(agent_info_filepath):
-                    raise ValueError(
-                        '{} has no coresponding "agent info" file'.format(counter_file)
+                    converted_csv_file = os.path.join(
+                        current_dir,
+                        os.path.basename(counter_file).replace(
+                            "_counter_collection", "_converted"
+                        ),
                     )
 
-                converted_csv_file = os.path.join(
-                    current_dir,
-                    os.path.basename(counter_file).replace(
-                        "_counter_collection", "_converted"
-                    ),
+                    v3_csv_to_v2_csv(counter_file, agent_info_filepath, converted_csv_file)
+
+                results_files_csv = glob.glob(workload_dir + "/out/pmc_1/*/*_converted.csv")
+            else:
+                results_files_csv = glob.glob(
+                    workload_dir + "/out/pmc_1/*/*_kernel_trace.csv"
                 )
-
-                v3_csv_to_v2_csv(counter_file, agent_info_filepath, converted_csv_file)
-
-            results_files_csv = glob.glob(workload_dir + "/out/pmc_1/*/*_converted.csv")
 
         # Combine results into single CSV file
         combined_results = pd.concat(

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -623,9 +623,11 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
             counter_info_csvs = glob.glob(
                 workload_dir + "/out/pmc_1/*/*_counter_collection.csv"
             )
-            
-            existing_counter_files_csv = [d for d in counter_info_csvs if os.path.isfile(d)]
-            
+
+            existing_counter_files_csv = [
+                d for d in counter_info_csvs if os.path.isfile(d)
+            ]
+
             if len(existing_counter_files_csv) > 0:
                 for counter_file in existing_counter_files_csv:
                     current_dir = os.path.dirname(counter_file)
@@ -637,7 +639,9 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
                     )
                     if not os.path.isfile(agent_info_filepath):
                         raise ValueError(
-                            '{} has no coresponding "agent info" file'.format(counter_file)
+                            '{} has no coresponding "agent info" file'.format(
+                                counter_file
+                            )
                         )
 
                     converted_csv_file = os.path.join(
@@ -647,9 +651,13 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
                         ),
                     )
 
-                    v3_csv_to_v2_csv(counter_file, agent_info_filepath, converted_csv_file)
+                    v3_csv_to_v2_csv(
+                        counter_file, agent_info_filepath, converted_csv_file
+                    )
 
-                results_files_csv = glob.glob(workload_dir + "/out/pmc_1/*/*_converted.csv")
+                results_files_csv = glob.glob(
+                    workload_dir + "/out/pmc_1/*/*_converted.csv"
+                )
             else:
                 results_files_csv = glob.glob(
                     workload_dir + "/out/pmc_1/*/*_kernel_trace.csv"


### PR DESCRIPTION
for support of csv output files from rocprofv3, counter csv file is used. But when a input file does not have any counters, like "timestamp", counter csv file is not generated and this cause crash. 

A handle of this case is implemented by this branch and resolves this crash.