### PR TITLE
Modify path to use gpu_model instead of gpu_series

### DIFF
--- a/src/roofline.py
+++ b/src/roofline.py
@@ -96,7 +96,7 @@ class Roofline:
             self.__run_parameters["workload_dir"] = os.path.join(
                 self.__run_parameters["workload_dir"],
                 self.__args.name,
-                self.__mspec.gpu_series,
+                self.__mspec.gpu_model,
             )
         # create new directory for roofline if it doesn't exist
         if not os.path.isdir(self.__run_parameters["workload_dir"]):


### PR DESCRIPTION
Modify path to use gpu_model instead of gpu_series to match other workload directory path creation/search points. Affects manual testing, does not seem to affect ctests.