### PR TITLE
Auto sync staging and mainline on a weekly cadence

### DIFF
--- a/.github/workflows/weekly-mainline-sync.yml
+++ b/.github/workflows/weekly-mainline-sync.yml
@@ -1,0 +1,27 @@
+name: Sync Mainline with Staging
+on:
+    workflow_dispatch:
+    schedule:
+      - cron: 0 5 * * sun
+
+jobs:
+  promote-stg-to-main:
+    if: github.repository == 'ROCm/rocprofiler-compute'
+    runs-on: ubuntu-latest
+    name: Promote Staging to Mainline
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+            ref: amd-mainline
+            fetch-depth: '0'
+
+      - name: Merge - Fast Forward Only
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git checkout amd-mainline
+          git checkout -b promote-staging-$(date +%F)
+          git merge --ff-only origin/amd-staging
+          git push -u origin HEAD
+          gh pr create --base amd-mainline --title "Promote \`amd-staging\` to \`amd-mainline\`" --fill --label "automerge"


### PR DESCRIPTION
Shameless rip-off of @dgaliffiAMD 's action in **rocprofiler-systems**. I think this is a good idea to ensure that we're keeping development in sync and don't overlook features ahead of new releases.