### PR TITLE
Pass accumulate counters to rocprofv3 using -E option

### DIFF
--- a/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -25,6 +25,7 @@
 import os
 import shlex
 
+import config
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from utils.utils import console_error, console_log, demarcate, replace_timestamps
 
@@ -44,6 +45,13 @@ class rocprof_v3_profiler(RocProfCompute_Base):
         if self.get_args().format_rocprof_output == "csv":
             rocprof_out_format = "csv"
         args = [
+            "-E",
+            os.path.join(
+                str(config.rocprof_compute_home),
+                "rocprof_compute_soc",
+                "profile_configs",
+                "accum_counters.yaml",
+            ),
             # v3 requires output directory argument
             "-d",
             self.get_args().path + "/" + "out",

--- a/src/rocprof_compute_soc/profile_configs/accum_counters.yaml
+++ b/src/rocprof_compute_soc/profile_configs/accum_counters.yaml
@@ -1,0 +1,25 @@
+SQ_IFETCH_LEVEL_ACCUM:
+  architectures:
+    gfx942/gfx941/gfx940/gfx90a:
+      expression: accumulate(SQ_IFETCH_LEVEL, HIGH_RES)
+  description: 'SQ_IFETCH_LEVEL accumulation'
+SQ_INST_LEVEL_LDS_ACCUM:
+  architectures:
+    gfx942/gfx941/gfx940/gfx90a:
+      expression: accumulate(SQ_INST_LEVEL_LDS, HIGH_RES)
+  description: 'SQ_INST_LEVEL_LDS accumulation'
+SQ_INST_LEVEL_SMEM_ACCUM:
+  architectures:
+    gfx942/gfx941/gfx940/gfx90a:
+      expression: accumulate(SQ_INST_LEVEL_SMEM, HIGH_RES)
+  description: 'SQ_INST_LEVEL_SMEM accumulation'
+SQ_INST_LEVEL_VMEM_ACCUM:
+  architectures:
+    gfx942/gfx941/gfx940/gfx90a:
+      expression: accumulate(SQ_INST_LEVEL_VMEM, HIGH_RES)
+  description: 'SQ_INST_LEVEL_VMEM accumulation'
+SQ_LEVEL_WAVES_ACCUM:
+  architectures:
+    gfx942/gfx941/gfx940/gfx90a:
+      expression: accumulate(SQ_LEVEL_WAVES, HIGH_RES)
+  description: 'SQ_LEVEL_WAVES accumulation'


### PR DESCRIPTION
rocprofv3 has a new -E option where extra counters can be passed instead of defining them in counter_defs.yaml.