### PR TITLE
Fix Read the Docs build error due to deprecated default

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,9 @@
 
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
Tiny change to fix failing RTD builds in PR previews and the live docs by explicitly specifying the path to the Sphinx configuration in .readthedocs.yaml.

Reason: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
