### PR TITLE
enable rocprofv3 for all old soc architectures

### DIFF
--- a/src/rocprof_compute_soc/soc_gfx906.py
+++ b/src/rocprof_compute_soc/soc_gfx906.py
@@ -42,7 +42,7 @@ class gfx906_soc(OmniSoC_Base):
                 )
             )
         )
-        self.set_compatible_profilers(["rocprofv1", "rocscope"])
+        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv3"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx906.py
+++ b/src/rocprof_compute_soc/soc_gfx906.py
@@ -42,7 +42,7 @@ class gfx906_soc(OmniSoC_Base):
                 )
             )
         )
-        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv3"])
+        self.set_compatible_profilers(["rocprofv1", "rocscope"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx908.py
+++ b/src/rocprof_compute_soc/soc_gfx908.py
@@ -42,7 +42,7 @@ class gfx908_soc(OmniSoC_Base):
                 )
             )
         )
-        self.set_compatible_profilers(["rocprofv1", "rocscope"])
+        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv3"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx90a.py
+++ b/src/rocprof_compute_soc/soc_gfx90a.py
@@ -55,7 +55,7 @@ class gfx90a_soc(OmniSoC_Base):
                     )
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2", "rocprofv3"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx940.py
+++ b/src/rocprof_compute_soc/soc_gfx940.py
@@ -56,7 +56,7 @@ class gfx940_soc(OmniSoC_Base):
                     )
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocprofv2", "rocprofv3"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx941.py
+++ b/src/rocprof_compute_soc/soc_gfx941.py
@@ -56,7 +56,7 @@ class gfx941_soc(OmniSoC_Base):
                     )
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocprofv2", "rocprofv3"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {


### PR DESCRIPTION
rocprofv3 was only enabled for gfx940 series. This branch enabled it for all old soc including gfx90a