### PR TITLE
fix crash for running rocprofv3 on mi100

### DIFF
--- a/src/rocprof_compute_profile/profiler_base.py
+++ b/src/rocprof_compute_profile/profiler_base.py
@@ -63,7 +63,7 @@ class RocProfCompute_Base:
     def get_args(self):
         return self.__args
 
-    def get_profiler_options(self, fname, soc_arch):
+    def get_profiler_options(self, fname, soc):
         """Fetch any version specific arguments required by profiler"""
         # assume no SoC specific options and return empty list by default
         return []
@@ -361,7 +361,7 @@ class RocProfCompute_Base:
                     console_debug(output)
             console_log("profiling", "Current input file: %s" % fname)
 
-            options = self.get_profiler_options(fname, self._soc.get_arch())
+            options = self.get_profiler_options(fname, self._soc)
             if (
                 self.__profiler == "rocprofv1"
                 or self.__profiler == "rocprofv2"

--- a/src/rocprof_compute_profile/profiler_base.py
+++ b/src/rocprof_compute_profile/profiler_base.py
@@ -361,7 +361,7 @@ class RocProfCompute_Base:
                     console_debug(output)
             console_log("profiling", "Current input file: %s" % fname)
 
-            options += self.get_profiler_options(fname, self._soc.get_arch())
+            options = self.get_profiler_options(fname, self._soc.get_arch())
             if (
                 self.__profiler == "rocprofv1"
                 or self.__profiler == "rocprofv2"

--- a/src/rocprof_compute_profile/profiler_base.py
+++ b/src/rocprof_compute_profile/profiler_base.py
@@ -63,7 +63,7 @@ class RocProfCompute_Base:
     def get_args(self):
         return self.__args
 
-    def get_profiler_options(self, fname):
+    def get_profiler_options(self, fname, soc_arch):
         """Fetch any version specific arguments required by profiler"""
         # assume no SoC specific options and return empty list by default
         return []
@@ -361,9 +361,7 @@ class RocProfCompute_Base:
                     console_debug(output)
             console_log("profiling", "Current input file: %s" % fname)
 
-            # Fetch any SoC/profiler specific profiling options
-            options = self._soc.get_profiler_options()
-            options += self.get_profiler_options(fname)
+            options += self.get_profiler_options(fname, self._soc.get_arch())
             if (
                 self.__profiler == "rocprofv1"
                 or self.__profiler == "rocprofv2"

--- a/src/rocprof_compute_profile/profiler_rocprof_v1.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v1.py
@@ -44,7 +44,7 @@ class rocprof_v1_profiler(RocProfCompute_Base):
         
         args = []
         # can be removed in the future. It supports gfx908 + v1
-        if soc_arch == "gfx_908": 
+        if soc_arch == "gfx908": 
             args += ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
     
         args += [

--- a/src/rocprof_compute_profile/profiler_rocprof_v1.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v1.py
@@ -38,14 +38,14 @@ class rocprof_v1_profiler(RocProfCompute_Base):
             or not self.get_args().roof_only
         )
 
-    def get_profiler_options(self, fname, soc_arch):
+    def get_profiler_options(self, fname, soc):
         fbase = Path(fname).stem
         app_cmd = self.get_args().remaining
         
         args = []
         # can be removed in the future. It supports gfx908 + v1
-        if soc_arch == "gfx908": 
-            args += ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
+        if soc.get_arch() == "gfx908": 
+            args += ["-m", soc.get_workload_perfmon_dir() + "/" + "metrics.xml"]
     
         args += [
             # v1 requires request for timestamps

--- a/src/rocprof_compute_profile/profiler_rocprof_v1.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v1.py
@@ -38,10 +38,16 @@ class rocprof_v1_profiler(RocProfCompute_Base):
             or not self.get_args().roof_only
         )
 
-    def get_profiler_options(self, fname):
+    def get_profiler_options(self, fname, soc_arch):
         fbase = Path(fname).stem
         app_cmd = self.get_args().remaining
-        args = [
+        
+        args = []
+        # can be removed in the future. It supports gfx908 + v1
+        if soc_arch == "gfx_908": 
+            args += ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
+    
+        args += [
             # v1 requires request for timestamps
             "--timestamp",
             "on",

--- a/src/rocprof_compute_profile/profiler_rocprof_v1.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v1.py
@@ -41,12 +41,12 @@ class rocprof_v1_profiler(RocProfCompute_Base):
     def get_profiler_options(self, fname, soc):
         fbase = Path(fname).stem
         app_cmd = self.get_args().remaining
-        
+
         args = []
         # can be removed in the future. It supports gfx908 + v1
-        if soc.get_arch() == "gfx908": 
+        if soc.get_arch() == "gfx908":
             args += ["-m", soc.get_workload_perfmon_dir() + "/" + "metrics.xml"]
-    
+
         args += [
             # v1 requires request for timestamps
             "--timestamp",

--- a/src/rocprof_compute_profile/profiler_rocprof_v2.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v2.py
@@ -46,7 +46,7 @@ class rocprof_v2_profiler(RocProfCompute_Base):
         
         args = []
         # can be removed in the future. It supports gfx908 + v2
-        if soc_arch == "gfx_908":
+        if soc_arch == "gfx908":
             args += ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
         
         args += [

--- a/src/rocprof_compute_profile/profiler_rocprof_v2.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v2.py
@@ -42,13 +42,12 @@ class rocprof_v2_profiler(RocProfCompute_Base):
     def get_profiler_options(self, fname, soc):
         fbase = Path(fname).stem
         app_cmd = shlex.split(self.get_args().remaining)
-        
-        
+
         args = []
         # can be removed in the future. It supports gfx908 + v2
         if soc.get_arch() == "gfx908":
             args += ["-m", soc.get_workload_perfmon_dir() + "/" + "metrics.xml"]
-        
+
         args += [
             # v2 requires output directory argument
             "-d",

--- a/src/rocprof_compute_profile/profiler_rocprof_v2.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v2.py
@@ -39,15 +39,15 @@ class rocprof_v2_profiler(RocProfCompute_Base):
             or not self.get_args().roof_only
         )
 
-    def get_profiler_options(self, fname, soc_arch):
+    def get_profiler_options(self, fname, soc):
         fbase = Path(fname).stem
         app_cmd = shlex.split(self.get_args().remaining)
         
         
         args = []
         # can be removed in the future. It supports gfx908 + v2
-        if soc_arch == "gfx908":
-            args += ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
+        if soc.get_arch() == "gfx908":
+            args += ["-m", soc.get_workload_perfmon_dir() + "/" + "metrics.xml"]
         
         args += [
             # v2 requires output directory argument

--- a/src/rocprof_compute_profile/profiler_rocprof_v2.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v2.py
@@ -39,10 +39,17 @@ class rocprof_v2_profiler(RocProfCompute_Base):
             or not self.get_args().roof_only
         )
 
-    def get_profiler_options(self, fname):
+    def get_profiler_options(self, fname, soc_arch):
         fbase = Path(fname).stem
         app_cmd = shlex.split(self.get_args().remaining)
-        args = [
+        
+        
+        args = []
+        # can be removed in the future. It supports gfx908 + v2
+        if soc_arch == "gfx_908":
+            args += ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
+        
+        args += [
             # v2 requires output directory argument
             "-d",
             self.get_args().path + "/" + "out",

--- a/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -40,7 +40,7 @@ class rocprof_v3_profiler(RocProfCompute_Base):
             or not self.get_args().roof_only
         )
 
-    def get_profiler_options(self, fname):
+    def get_profiler_options(self, fname, soc_arch):
         app_cmd = shlex.split(self.get_args().remaining)
         trace_option = "--kernel-trace"
         rocprof_out_format = "json"

--- a/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -40,7 +40,7 @@ class rocprof_v3_profiler(RocProfCompute_Base):
             or not self.get_args().roof_only
         )
 
-    def get_profiler_options(self, fname, soc_arch):
+    def get_profiler_options(self, fname, soc):
         app_cmd = shlex.split(self.get_args().remaining)
         trace_option = "--kernel-trace"
         rocprof_out_format = "json"

--- a/src/rocprof_compute_soc/soc_base.py
+++ b/src/rocprof_compute_soc/soc_base.py
@@ -98,12 +98,6 @@ class OmniSoC_Base:
         return self.__compatible_profilers
 
     @demarcate
-    def get_profiler_options(self):
-        """Fetch any SoC specific arguments required by the profiler"""
-        # assume no SoC specific options and return empty list by default
-        return []
-
-    @demarcate
     def populate_mspec(self):
         from utils.specs import run, search, total_sqc, total_xcds
 

--- a/src/rocprof_compute_soc/soc_gfx908.py
+++ b/src/rocprof_compute_soc/soc_gfx908.py
@@ -25,7 +25,7 @@
 from pathlib import Path
 
 import config
-from rocprof_compute_soc.soc_base import OmniSoC_Base, using_v3
+from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.utils import console_error, demarcate
 
 

--- a/src/rocprof_compute_soc/soc_gfx908.py
+++ b/src/rocprof_compute_soc/soc_gfx908.py
@@ -69,14 +69,6 @@ class gfx908_soc(OmniSoC_Base):
             self._mspec.max_mclk = 1200
             self._mspec.cur_mclk = 1200
 
-    @demarcate
-    def get_profiler_options(self):
-        # Mi100 requires a custom xml config
-        if not using_v3:
-            return ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
-        else:
-            return []
-
     # -----------------------
     # Required child methods
     # -----------------------

--- a/src/rocprof_compute_soc/soc_gfx908.py
+++ b/src/rocprof_compute_soc/soc_gfx908.py
@@ -25,9 +25,8 @@
 from pathlib import Path
 
 import config
-from rocprof_compute_soc.soc_base import OmniSoC_Base
+from rocprof_compute_soc.soc_base import OmniSoC_Base, using_v3
 from utils.utils import console_error, demarcate
-from rocprof_compute_soc.soc_base import using_v3
 
 
 class gfx908_soc(OmniSoC_Base):

--- a/src/rocprof_compute_soc/soc_gfx908.py
+++ b/src/rocprof_compute_soc/soc_gfx908.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.utils import console_error, demarcate
+from rocprof_compute_soc.soc_base import using_v3
 
 
 class gfx908_soc(OmniSoC_Base):
@@ -72,7 +73,10 @@ class gfx908_soc(OmniSoC_Base):
     @demarcate
     def get_profiler_options(self):
         # Mi100 requires a custom xml config
-        return ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
+        if not using_v3:
+            return ["-m", self.get_workload_perfmon_dir() + "/" + "metrics.xml"]
+        else:
+            return []
 
     # -----------------------
     # Required child methods

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -595,7 +595,7 @@ def run_prof(
     ):
         new_env = os.environ.copy()
         new_env["ROCPROFILER_INDIVIDUAL_XCC_MODE"] = "1"
-        
+
     is_timestamps = False
     if path(fname).name == "timestamps.txt":
         is_timestamps = True

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -595,7 +595,10 @@ def run_prof(
     ):
         new_env = os.environ.copy()
         new_env["ROCPROFILER_INDIVIDUAL_XCC_MODE"] = "1"
-
+        
+    is_timestamps = False
+    if path(fname).name == "timestamps.txt":
+        is_timestamps = True
     time_1 = time.time()
 
     # profile the app
@@ -686,10 +689,12 @@ def run_prof(
                 results_files_csv = glob.glob(
                     workload_dir + "/out/pmc_1/*/*_converted.csv"
                 )
-            else:
+            elif is_timestamps:
                 results_files_csv = glob.glob(
                     workload_dir + "/out/pmc_1/*/*_kernel_trace.csv"
                 )
+            else:
+                return
 
         else:
             console_error("The output file of rocprofv3 can only support json or csv!!!")

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -690,10 +690,12 @@ def run_prof(
                     workload_dir + "/out/pmc_1/*/*_converted.csv"
                 )
             elif is_timestamps:
+                # when the input is timestamps, we know counter csv file is not generated and will instead parse kernel trace file
                 results_files_csv = glob.glob(
                     workload_dir + "/out/pmc_1/*/*_kernel_trace.csv"
                 )
             else:
+                # when the input is not for timestamps, and counter csv file is not generated, we assume failed rocprof run and will completely bypass the file generation and merging for current pmc
                 return
 
         else:


### PR DESCRIPTION
removed "-m" parameter for rocprofv3 when on mi100 and add mechanism to avoid crash when rocprofv3 does not generate counter csv file.