### PR TITLE
Update profiler trace launches

### DIFF
--- a/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -48,10 +48,10 @@ class rocprof_v3_profiler(RocProfCompute_Base):
         if self.get_args().format_rocprof_output == "csv":
             rocprof_out_format = "csv"
 
-        if self.get_args().hip_trace:
-            trace_option += " " + "--hip-trace"
         if self.get_args().kokkos_trace:
-            trace_option += " " + "--kokkos-trace"
+            trace_option = "--kokkos-trace"
+        if self.get_args().hip_trace:
+            trace_option = "--hip-trace"
 
         args = [
             "-E",


### PR DESCRIPTION
The different tracing modes (kernel trace, kokkos/marker trace, and hip trace) are now exclusive of each other based on latest rocprofv3 updates.