### PR TITLE
Specify path to config file as it's now required by readthedocs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,9 @@
 
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
Must specify path to config file according to readthedocs [blog](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/)