### PR TITLE
Fix links in docs

### DIFF
--- a/docs/conceptual/definitions.rst
+++ b/docs/conceptual/definitions.rst
@@ -95,7 +95,7 @@ Memory type
 
 AMD Instinct accelerators contain a number of different memory allocation
 types to enable the HIP language's
-:doc:`memory coherency model <hip:how-to/programming_manual>`.
+:doc:`memory coherency model <hip:how-to/hip_runtime_api/memory_management/coherence_control>`.
 These memory types are broadly similar between AMD Instinct accelerator
 generations, but may differ in exact implementation.
 

--- a/docs/tutorial/learning-resources.rst
+++ b/docs/tutorial/learning-resources.rst
@@ -20,4 +20,4 @@ ROCm Compute Profiler example exercises
   `<https://github.com/amd/HPCTrainingExamples/tree/main/OmniperfExamples>`__
 
 AMD Instinct™ tuning guides
-  :doc:`rocm:how-to/tuning-guides/mi300x/workload`
+  :doc:`rocm:how-to/rocm-for-ai/inference-optimization/workload`


### PR DESCRIPTION
Small fix to update external links in docs due to changed file paths:
- https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_runtime_api/memory_management/coherence_control.html
- https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference-optimization/workload.html