### PR TITLE
Parser: to_int() return None instead of np.nan (#569)

### DIFF
--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -163,7 +163,7 @@ def to_std(a):
 
 def to_int(a):
     if str(type(a)) == "<class 'NoneType'>":
-        return np.nan
+        return None
     elif isinstance(a, (int, float, np.int64)):
         return int(a)
     elif isinstance(a, pd.core.series.Series):
@@ -811,9 +811,8 @@ def eval_metric(dfs, dfs_type, sys_info, raw_pmc_df, debug):
                                 # print("eval_metric", id, expr)
                                 try:
                                     out = eval(compile(row[expr], "<string>", "eval"))
-                                    if row.name != "19.1.1" and np.isnan(
-                                        out
-                                    ):  # Special exception for unique format of Active CUs in mem chart
+
+                                    if np.isnan(out):
                                         row[expr] = ""
                                     else:
                                         row[expr] = out


### PR DESCRIPTION
* [Parser: to_int() return None instead of np.nan (](https://github.com/ROCm/rocprofiler-compute/pull/575/commits/29e8fe91e3817077e6f7abb58b82fb09617b4311)https://github.com/ROCm/rocprofiler-compute/pull/569[)](https://github.com/ROCm/rocprofiler-compute/pull/575/commits/29e8fe91e3817077e6f7abb58b82fb09617b4311)

* [Changelog: remove spatial multiplexing experimental feature](https://github.com/ROCm/rocprofiler-compute/pull/575/commits/167c30073848f7544d8f3bf1dd37d7569715dfac)