### PR TITLE
Fix name in package manager install docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,10 +387,14 @@ add_custom_target(
     COMMAND
         ${Python3_EXECUTABLE} -m nuitka --mode=onefile
         --include-data-files=${PROJECT_SOURCE_DIR}/VERSION*=./ --enable-plugin=no-qt
-        --include-package-data=dash_svg --include-package=dash_bootstrap_components
-        --include-package=plotly --include-package-data=kaleido
+        --include-package=dash_svg --include-package-data=dash_svg
+        --include-package=dash_bootstrap_components
+        --include-package-data=dash_bootstrap_components --include-package=plotly
+        --include-package-data=plotly --include-package=kaleido
+        --include-package-data=kaleido --include-package=rocprof_compute_analyze
+        --include-package-data=rocprof_compute_analyze
         --include-package=rocprof_compute_soc --include-package-data=rocprof_compute_soc
-        --include-package-data=utils rocprof-compute
+        --include-package=utils --include-package-data=utils rocprof-compute
     # Remove library rpath from executable
     COMMAND patchelf --remove-rpath rocprof-compute.bin
     # Move to build directory

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Users may checkout `amd-staging` to preview upcoming features.
 
 To quickly get the environment (bash shell) for building and testing, run the following commands:
 * `cd docker`
-* `docker compose -f docker-compose.test.yml run test`
+* `docker compose -f docker-compose.test.yml up --force-recreate -d && docker attach docker-test-1`
 
 Inside the docker container, clean, build and install the project with tests enabled:
 ```
@@ -60,7 +60,7 @@ NOTE: This Dockerfile uses `rocm/dev-ubuntu-22.04` as the base image
 
 To create a standalone binary, run the following commands:
 * `cd docker`
-* `docker compose -f docker-compose.standalone.yml run standalone`
+* `docker compose -f docker-compose.standalone.yml up --force-recreate -d && docker attach docker-standalone-1`
 
 You should find the rocprof-compute.bin standalone binary inside the `build` folder in the root directory of the project.
 

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -25,6 +25,6 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 # Install any dependencies specified in requirements.txt
 # Run interactive bash shell
 CMD ["/bin/bash", "-c", "\
-    python3.10 -m pip install -r requirements.txt -r requirements-test.txt \
+    python3 -m pip install -r requirements.txt -r requirements-test.txt \
     && exec /bin/bash \
 "]

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -10,3 +10,7 @@ services:
       - seccomp:unconfined
     volumes:
       - ../:/app
+    ports:
+      - 8050:8050
+    tty: true
+    stdin_open: true

--- a/docs/install/core-install.rst
+++ b/docs/install/core-install.rst
@@ -225,7 +225,7 @@ software stack.
 
          $ sudo apt install rocprofiler-compute
          # Include rocprofiler-compute in your system PATH
-         $ sudo update-alternatives --install /usr/bin/rocprofiler-compute rocprof-compute /opt/rocm/bin/rocprofiler-compute 0
+         $ sudo update-alternatives --install /usr/bin/rocprof-compute rocprof-compute /opt/rocm/bin/rocprof-compute 0
          # Install Python dependencies
          $ python3 -m pip install -r /opt/rocm/libexec/rocprofiler-compute/requirements.txt
 
@@ -235,7 +235,7 @@ software stack.
 
          $ sudo dnf install rocprofiler-compute
          # Include rocprofiler-compute in your system PATH
-         $ sudo update-alternatives --install /usr/bin/rocprofiler-compute rocprof-compute /opt/rocm/bin/rocprofiler-compute 0
+         $ sudo update-alternatives --install /usr/bin/rocprof-compute rocprof-compute /opt/rocm/bin/rocprof-compute 0
          # Install Python dependencies
          $ python3 -m pip install -r /opt/rocm/libexec/rocprofiler-compute/requirements.txt
 
@@ -245,7 +245,7 @@ software stack.
 
          $ sudo zypper install rocprofiler-compute
          # Include rocprofiler-compute in your system PATH
-         $ sudo update-alternatives --install /usr/bin/rocprofiler-compute rocprof-compute /opt/rocm/bin/rocprofiler-compute 0
+         $ sudo update-alternatives --install /usr/bin/rocprof-compute rocprof-compute /opt/rocm/bin/rocprof-compute 0
          # Install Python dependencies
          $ python3 -m pip install -r /opt/rocm/libexec/rocprofiler-compute/requirements.txt
 

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -624,6 +624,18 @@ def run_prof(
     if rocprof_cmd.endswith("v2"):
         # rocprofv2 has separate csv files for each process
         results_files = glob.glob(workload_dir + "/out/pmc_1/results_*.csv")
+
+        # Combine results into single CSV file
+        combined_results = pd.concat(
+            [pd.read_csv(f) for f in results_files], ignore_index=True
+        )
+
+        # Overwrite column to ensure unique IDs.
+        combined_results["Dispatch_ID"] = range(0, len(combined_results))
+
+        combined_results.to_csv(
+            workload_dir + "/out/pmc_1/results_" + fbase + ".csv", index=False
+        )
     elif rocprof_cmd.endswith("v3"):
         # rocprofv3 requires additional processing for each process
         results_files = process_rocprofv3_output(
@@ -638,17 +650,17 @@ def run_prof(
             process_kokkos_trace_output(workload_dir, fbase)
         # TODO: add hip trace output processing
 
-    # Combine results into single CSV file
-    combined_results = pd.concat(
-        [pd.read_csv(f) for f in results_files], ignore_index=True
-    )
+        # Combine results into single CSV file
+        combined_results = pd.concat(
+            [pd.read_csv(f) for f in results_files], ignore_index=True
+        )
 
-    # Overwrite column to ensure unique IDs.
-    combined_results["Dispatch_ID"] = range(0, len(combined_results))
+        # Overwrite column to ensure unique IDs.
+        combined_results["Dispatch_ID"] = range(0, len(combined_results))
 
-    combined_results.to_csv(
-        workload_dir + "/out/pmc_1/results_" + fbase + ".csv", index=False
-    )
+        combined_results.to_csv(
+            workload_dir + "/out/pmc_1/results_" + fbase + ".csv", index=False
+        )
 
     if new_env:
         # flatten tcc for applicable mi300 input


### PR DESCRIPTION
`rocprofiler-compute` should be `rocprof-compute` here: 

`sudo update-alternatives --install /usr/bin/rocprofiler-compute rocprof-compute /opt/rocm/bin/rocprofiler-compute 0`

https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/install/core-install.html#install-via-package-manager