### PR TITLE
Disable --kokkos-trace

### DIFF
--- a/src/argparser.py
+++ b/src/argparser.py
@@ -153,7 +153,8 @@ Examples:
         required=False,
         default=False,
         action="store_true",
-        help="\t\t\tKokkos trace, traces Kokkos API calls.",
+        help=argparse.SUPPRESS,
+        #help="\t\t\tKokkos trace, traces Kokkos API calls.",
     )
     profile_group.add_argument(
         "-k",

--- a/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -50,6 +50,10 @@ class rocprof_v3_profiler(RocProfCompute_Base):
 
         if self.get_args().kokkos_trace:
             trace_option = "--kokkos-trace"
+            # NOTE: --kokkos-trace feature is incomplete and is disabled for now.
+            console_error(
+                "The option '--kokkos-trace' is not supported in the current version of rocprof-compute. This functionality is planned for a future release. Please adjust your profiling options accordingly."
+            )
         if self.get_args().hip_trace:
             trace_option = "--hip-trace"
 


### PR DESCRIPTION
- Introduce error message when `--kokkos-trace` option is detected, and exit the program.
- Remove `--kokkos-trace` from help menu.