### PR TITLE
Standalone binary no self execute fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,11 +391,11 @@ add_custom_target(
     # Create VERSION.sha file
     COMMAND git -C ${PROJECT_SOURCE_DIR} rev-parse HEAD > VERSION.sha
     # Build standalone binary
-    # NOTE: --no-deployment-flag=self-execution is used to avoid self-execution and fork bombs
-    # as explained in https://nuitka.net/user-documentation/common-issue-solutions.html#fork-bombs-self-execution
+    # NOTE: --no-deployment-flag=self-execution is used to avoid self-execution and fork
+    # bombs as explained in
+    # https://nuitka.net/user-documentation/common-issue-solutions.html#fork-bombs-self-execution
     COMMAND
-        ${Python3_EXECUTABLE} -m nuitka --mode=onefile
-        --no-deployment-flag=self-execution --jobs 8
+        ${Python3_EXECUTABLE} -m nuitka --mode=onefile --no-deployment-flag=self-execution
         --include-data-files=${PROJECT_SOURCE_DIR}/VERSION*=./ --enable-plugin=no-qt
         --include-package=dash_svg --include-package-data=dash_svg
         --include-package=dash_bootstrap_components

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,8 +391,11 @@ add_custom_target(
     # Create VERSION.sha file
     COMMAND git -C ${PROJECT_SOURCE_DIR} rev-parse HEAD > VERSION.sha
     # Build standalone binary
+    # NOTE: --no-deployment-flag=self-execution is used to avoid self-execution and fork bombs
+    # as explained in https://nuitka.net/user-documentation/common-issue-solutions.html#fork-bombs-self-execution
     COMMAND
         ${Python3_EXECUTABLE} -m nuitka --mode=onefile
+        --no-deployment-flag=self-execution --jobs 8
         --include-data-files=${PROJECT_SOURCE_DIR}/VERSION*=./ --enable-plugin=no-qt
         --include-package=dash_svg --include-package-data=dash_svg
         --include-package=dash_bootstrap_components


### PR DESCRIPTION
Make standalone binary with no self execution option in Nuitka to avoid fork bombs when profiling multi-processing programs as explained in https://nuitka.net/user-documentation/common-issue-solutions.html#fork-bombs-self-execution