### PR TITLE
Force kaleido version to be no greater than 0.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ tabulate
 tqdm
 dash-svg
 dash-bootstrap-components
-kaleido
+kaleido==0.2.1
 setuptools
 plotille


### PR DESCRIPTION
Higher versions (eg. 0.4.1) have external dependencies that are causing errors and forcing early exits without creating roof plots