### PR TITLE
Remove dependency on en_US.UTF-8 locale

### DIFF
--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -29,8 +29,6 @@ jobs:
           sudo apt-get install -y git
           sudo apt-get install -y python3-pip
           sudo apt-get install -y cmake
-          sudo apt-get install -y locales
-          sudo locale-gen en_US.UTF-8
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Python prereqs

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -13,9 +13,6 @@ RUN apt-get update && apt-get install -y \
 # Allows running git commands in /app
 RUN git config --global --add safe.directory /app
 
-# Generate the desired locale
-RUN locale-gen en_US.UTF-8
-
 # Install Python 3.10 and pip
 RUN apt-get install -y python3.10 python3.10-venv python3.10-dev python3-pip
 

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1120,10 +1120,10 @@ def print_status(msg):
 
 def set_locale_encoding():
     try:
-        locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+        locale.setlocale(locale.LC_ALL, "C.UTF-8")
     except locale.Error as error:
         console_error(
-            "Please ensure that the 'en_US.UTF-8' locale is available on your system.",
+            "Please ensure that the 'C.UTF-8' locale is available on your system.",
             exit=False,
         )
         console_error(error)


### PR DESCRIPTION
This PR removes the dependency on en_US.UTF-8 locale. Instead use the C.UTF-8 locale which is the default UTF-8 locale included on most Linux distributions.