### PR TITLE
Fix kernel filtering when using rocprofv3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 ### Resolved issues
 
 * Fixed option specs-correction
+* Fixed kernel name and kernel dispatch filtering when using rocprof v3
+
+### Known issues
+
+* gpu id filtering is not supported when using rocprof v3
 
 ## (Unreleased) ROCm Compute Profiler 3.1.0 for ROCm 6.4.0
 

--- a/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -71,8 +71,25 @@ class rocprof_v3_profiler(RocProfCompute_Base):
             trace_option,
             "--output-format",
             rocprof_out_format,
-            "--",
         ]
+        # Kernel filtering
+        if self.get_args().kernel:
+            args.extend(["--kernel-include-regex", "|".join(self.get_args().kernel)])
+        # Dispatch filtering
+        dispatch = []
+        # rocprofv3 dispatch indexing is inclusive and starts from 1
+        if self.get_args().dispatch:
+            for dispatch_id in self.get_args().dispatch:
+                if ":" in dispatch_id:
+                    tokens = dispatch_id.split(":")
+                    # 4:7 -> 5-7
+                    dispatch.append(f"{int(tokens[0]) + 1}-{tokens[1]}")
+                else:
+                    # 4 -> 5
+                    dispatch.append(f"{int(dispatch_id) + 1}")
+        if dispatch:
+            args.extend(["--kernel-iteration-range", f"[{','.join(dispatch)}]"])
+        args.append("--")
         args.extend(app_cmd)
         return args
 


### PR DESCRIPTION
When using rocprof v3:
* Use --kernel-include-regex for kernel name filtering
* Use --kernel-iteration-range for kernel dispatch filtering

Update changelog