### PR TITLE
Fix incorrect logging in `mi_gpu_spec.py`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@ default_stages: [pre-commit]
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   # Python import sorting
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
   # Python formatting (Using this mirror lets us use mypyc-compiled black, which is about 2x faster)
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
       - id: black

--- a/src/rocprof-compute
+++ b/src/rocprof-compute
@@ -36,7 +36,7 @@ try:
     from importlib import metadata
 
     from rocprof_compute_base import RocProfCompute
-    from utils.utils import console_error
+    from utils.logger import console_error
 except ImportError as e:
     # print("Failed to import required modules: " + str(e))
     pass

--- a/src/rocprof_compute_analyze/analysis_base.py
+++ b/src/rocprof_compute_analyze/analysis_base.py
@@ -30,8 +30,8 @@ from collections import OrderedDict
 from pathlib import Path
 
 from utils import file_io, parser, schema
-from utils.utils import is_workload_empty, merge_counters_spatial_multiplex
 from utils.logger import console_debug, console_error, console_log, demarcate
+from utils.utils import is_workload_empty, merge_counters_spatial_multiplex
 
 
 class OmniAnalyze_Base:

--- a/src/rocprof_compute_analyze/analysis_base.py
+++ b/src/rocprof_compute_analyze/analysis_base.py
@@ -31,12 +31,7 @@ from pathlib import Path
 
 from utils import file_io, parser, schema
 from utils.utils import is_workload_empty, merge_counters_spatial_multiplex
-from utils.logger import (
-    console_debug,
-    console_error,
-    console_log,
-    demarcate
-)
+from utils.logger import console_debug, console_error, console_log, demarcate
 
 
 class OmniAnalyze_Base:

--- a/src/rocprof_compute_analyze/analysis_base.py
+++ b/src/rocprof_compute_analyze/analysis_base.py
@@ -30,13 +30,12 @@ from collections import OrderedDict
 from pathlib import Path
 
 from utils import file_io, parser, schema
-from utils.utils import (
+from utils.utils import is_workload_empty, merge_counters_spatial_multiplex
+from utils.logger import (
     console_debug,
     console_error,
     console_log,
-    demarcate,
-    is_workload_empty,
-    merge_counters_spatial_multiplex,
+    demarcate
 )
 
 

--- a/src/rocprof_compute_analyze/analysis_cli.py
+++ b/src/rocprof_compute_analyze/analysis_cli.py
@@ -25,7 +25,7 @@
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
-from utils.utils import console_error, demarcate
+from utils.logger import console_error, demarcate
 
 
 class cli_analysis(OmniAnalyze_Base):

--- a/src/rocprof_compute_analyze/analysis_webui.py
+++ b/src/rocprof_compute_analyze/analysis_webui.py
@@ -35,7 +35,7 @@ from dash.dependencies import Input, Output, State
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser
 from utils.gui import build_bar_chart, build_table_chart
-from utils.utils import console_debug, console_error, demarcate
+from utils.logger import console_debug, console_error, demarcate
 
 PROJECT_NAME = "rocprofiler-compute"
 

--- a/src/rocprof_compute_base.py
+++ b/src/rocprof_compute_base.py
@@ -38,14 +38,14 @@ import config
 from argparser import omniarg_parser
 from utils import file_io, parser, schema
 from utils.logger import (
-    setup_console_handler,
-    setup_file_handler,
-    setup_logging_priority,
     console_debug,
     console_error,
     console_log,
     console_warning,
     demarcate,
+    setup_console_handler,
+    setup_file_handler,
+    setup_logging_priority,
 )
 from utils.mi_gpu_spec import get_gpu_series_dict, parse_mi_gpu_spec
 from utils.specs import MachineSpecs, generate_machine_specs

--- a/src/rocprof_compute_base.py
+++ b/src/rocprof_compute_base.py
@@ -41,15 +41,15 @@ from utils.logger import (
     setup_console_handler,
     setup_file_handler,
     setup_logging_priority,
-)
-from utils.mi_gpu_spec import get_gpu_series_dict, parse_mi_gpu_spec
-from utils.specs import MachineSpecs, generate_machine_specs
-from utils.utils import (
     console_debug,
     console_error,
     console_log,
     console_warning,
     demarcate,
+)
+from utils.mi_gpu_spec import get_gpu_series_dict, parse_mi_gpu_spec
+from utils.specs import MachineSpecs, generate_machine_specs
+from utils.utils import (
     detect_rocprof,
     get_submodules,
     get_version,

--- a/src/rocprof_compute_profile/profiler_base.py
+++ b/src/rocprof_compute_profile/profiler_base.py
@@ -35,13 +35,15 @@ import pandas as pd
 from tqdm import tqdm
 
 import config
-from utils.utils import (
-    capture_subprocess_output,
+from utils.logger import (
     console_debug,
     console_error,
     console_log,
     console_warning,
     demarcate,
+)
+from utils.utils import (
+    capture_subprocess_output,
     gen_sysinfo,
     print_status,
     run_prof,

--- a/src/rocprof_compute_profile/profiler_rocprof_v1.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v1.py
@@ -27,7 +27,8 @@ from pathlib import Path
 
 import config
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
-from utils.utils import console_log, demarcate, replace_timestamps, store_app_cmd
+from utils.utils import console_log, replace_timestamps, store_app_cmd
+from utils.logger import demarcate
 
 
 class rocprof_v1_profiler(RocProfCompute_Base):

--- a/src/rocprof_compute_profile/profiler_rocprof_v1.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v1.py
@@ -27,8 +27,8 @@ from pathlib import Path
 
 import config
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
-from utils.utils import console_log, replace_timestamps, store_app_cmd
-from utils.logger import demarcate
+from utils.logger import console_log, demarcate
+from utils.utils import replace_timestamps, store_app_cmd
 
 
 class rocprof_v1_profiler(RocProfCompute_Base):

--- a/src/rocprof_compute_profile/profiler_rocprof_v2.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v2.py
@@ -28,8 +28,8 @@ from pathlib import Path
 
 import config
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
-from utils.utils import console_log, replace_timestamps, store_app_cmd
-from utils.logger import demarcate
+from utils.logger import console_log, demarcate
+from utils.utils import replace_timestamps, store_app_cmd
 
 
 class rocprof_v2_profiler(RocProfCompute_Base):

--- a/src/rocprof_compute_profile/profiler_rocprof_v2.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v2.py
@@ -28,7 +28,8 @@ from pathlib import Path
 
 import config
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
-from utils.utils import console_log, demarcate, replace_timestamps, store_app_cmd
+from utils.utils import console_log, replace_timestamps, store_app_cmd
+from utils.logger import demarcate
 
 
 class rocprof_v2_profiler(RocProfCompute_Base):

--- a/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -28,7 +28,8 @@ from pathlib import Path
 
 import config
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
-from utils.utils import console_error, console_log, demarcate, replace_timestamps
+from utils.logger import console_error, console_log, demarcate
+from utils.utils import replace_timestamps
 
 
 class rocprof_v3_profiler(RocProfCompute_Base):

--- a/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -29,7 +29,6 @@ from pathlib import Path
 import config
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from utils.logger import console_error, console_log, demarcate
-from utils.utils import replace_timestamps
 
 
 class rocprof_v3_profiler(RocProfCompute_Base):

--- a/src/rocprof_compute_profile/profiler_rocscope.py
+++ b/src/rocprof_compute_profile/profiler_rocscope.py
@@ -23,7 +23,7 @@
 ##############################################################################el
 
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
-from utils.utils import console_log, demarcate
+from utils.logger import console_log, demarcate
 
 
 class rocscope_profiler(RocProfCompute_Base):

--- a/src/rocprof_compute_soc/soc_base.py
+++ b/src/rocprof_compute_soc/soc_base.py
@@ -35,8 +35,6 @@ import pandas as pd
 import yaml
 
 import config
-from utils.mi_gpu_spec import get_gpu_model, get_gpu_series
-from utils.parser import build_in_vars, supported_denom
 from utils.logger import (
     console_debug,
     console_error,
@@ -44,10 +42,11 @@ from utils.logger import (
     console_warning,
     demarcate,
 )
+from utils.mi_gpu_spec import get_gpu_model, get_gpu_series
+from utils.parser import build_in_vars, supported_denom
 from utils.utils import (
     capture_subprocess_output,
     convert_metric_id_to_panel_idx,
-    demarcate,
     detect_rocprof,
     get_submodules,
     is_tcc_channel_counter,

--- a/src/rocprof_compute_soc/soc_base.py
+++ b/src/rocprof_compute_soc/soc_base.py
@@ -37,12 +37,15 @@ import yaml
 import config
 from utils.mi_gpu_spec import get_gpu_model, get_gpu_series
 from utils.parser import build_in_vars, supported_denom
-from utils.utils import (
-    capture_subprocess_output,
+from utils.logger import (
     console_debug,
     console_error,
     console_log,
     console_warning,
+    demarcate,
+)
+from utils.utils import (
+    capture_subprocess_output,
     convert_metric_id_to_panel_idx,
     demarcate,
     detect_rocprof,

--- a/src/rocprof_compute_soc/soc_gfx906.py
+++ b/src/rocprof_compute_soc/soc_gfx906.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
-from utils.utils import console_error, demarcate
+from utils.logger import console_error, demarcate
 
 
 class gfx906_soc(OmniSoC_Base):

--- a/src/rocprof_compute_soc/soc_gfx908.py
+++ b/src/rocprof_compute_soc/soc_gfx908.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
-from utils.utils import console_error, demarcate
+from utils.logger import console_error, demarcate
 
 
 class gfx908_soc(OmniSoC_Base):

--- a/src/rocprof_compute_soc/soc_gfx90a.py
+++ b/src/rocprof_compute_soc/soc_gfx90a.py
@@ -27,7 +27,8 @@ from pathlib import Path
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from roofline import Roofline
-from utils.utils import console_log, demarcate, mibench
+from utils.logger import console_log, demarcate
+from utils.utils import mibench
 
 
 class gfx90a_soc(OmniSoC_Base):

--- a/src/rocprof_compute_soc/soc_gfx940.py
+++ b/src/rocprof_compute_soc/soc_gfx940.py
@@ -27,7 +27,8 @@ from pathlib import Path
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from roofline import Roofline
-from utils.utils import console_error, console_log, demarcate, mibench
+from utils.logger import console_error, console_log, demarcate
+from utils.utils import mibench
 
 
 class gfx940_soc(OmniSoC_Base):

--- a/src/rocprof_compute_soc/soc_gfx941.py
+++ b/src/rocprof_compute_soc/soc_gfx941.py
@@ -27,7 +27,8 @@ from pathlib import Path
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from roofline import Roofline
-from utils.utils import console_error, console_log, demarcate, mibench
+from utils.logger import console_error, console_log, demarcate
+from utils.utils import mibench
 
 
 class gfx941_soc(OmniSoC_Base):

--- a/src/rocprof_compute_soc/soc_gfx942.py
+++ b/src/rocprof_compute_soc/soc_gfx942.py
@@ -27,7 +27,8 @@ from pathlib import Path
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from roofline import Roofline
-from utils.utils import console_error, console_log, demarcate, mibench
+from utils.logger import console_error, console_log, demarcate
+from utils.utils import mibench
 
 
 class gfx942_soc(OmniSoC_Base):

--- a/src/roofline.py
+++ b/src/roofline.py
@@ -33,6 +33,12 @@ import pandas as pd
 import plotly.graph_objects as go
 from dash import dcc, html
 
+from utils.logger import (
+    console_debug,
+    console_error,
+    console_log,
+    demarcate,
+)
 from utils.roofline_calc import (
     MFMA_DATATYPES,
     PEAK_OPS_DATATYPES,
@@ -41,12 +47,6 @@ from utils.roofline_calc import (
     constuct_roof,
 )
 from utils.utils import mibench
-from utils.logger import (
-    console_debug,
-    console_error,
-    console_log,
-    demarcate,
-)
 
 SYMBOLS = [0, 1, 2, 3, 4, 5, 13, 17, 18, 20]
 

--- a/src/roofline.py
+++ b/src/roofline.py
@@ -40,13 +40,12 @@ from utils.roofline_calc import (
     calc_ai,
     constuct_roof,
 )
-from utils.utils import (
+from utils.utils import mibench
+from utils.logger import (
     console_debug,
     console_error,
     console_log,
     demarcate,
-    gen_sysinfo,
-    mibench,
 )
 
 SYMBOLS = [0, 1, 2, 3, 4, 5, 13, 17, 18, 20]

--- a/src/utils/db_connector.py
+++ b/src/utils/db_connector.py
@@ -32,13 +32,13 @@ from pymongo import MongoClient
 from tqdm import tqdm
 
 from utils.kernel_name_shortener import kernel_name_shortener
-from utils.utils import (
+from utils.utils import is_workload_empty
+from utils.logger import (
     console_debug,
     console_error,
     console_log,
     console_warning,
     demarcate,
-    is_workload_empty,
 )
 
 MAX_SERVER_SEL_DELAY = 5000  # 5 sec connection timeout

--- a/src/utils/db_connector.py
+++ b/src/utils/db_connector.py
@@ -32,7 +32,6 @@ from pymongo import MongoClient
 from tqdm import tqdm
 
 from utils.kernel_name_shortener import kernel_name_shortener
-from utils.utils import is_workload_empty
 from utils.logger import (
     console_debug,
     console_error,
@@ -40,6 +39,7 @@ from utils.logger import (
     console_warning,
     demarcate,
 )
+from utils.utils import is_workload_empty
 
 MAX_SERVER_SEL_DELAY = 5000  # 5 sec connection timeout
 

--- a/src/utils/file_io.py
+++ b/src/utils/file_io.py
@@ -36,7 +36,7 @@ import yaml
 import config
 from utils import schema
 from utils.kernel_name_shortener import kernel_name_shortener
-from utils.utils import console_debug, console_error, console_log, demarcate
+from utils.logger import console_debug, console_error, console_log, demarcate
 
 # TODO: use pandas chunksize or dask to read really large csv file
 # from dask import dataframe as dd

--- a/src/utils/gui.py
+++ b/src/utils/gui.py
@@ -28,7 +28,7 @@ import plotly.express as px
 from dash import dash_table, html
 
 from utils import schema
-from utils.utils import console_error
+from utils.logger import console_error
 
 pd.set_option(
     "mode.chained_assignment", None

--- a/src/utils/gui_components/memchart.py
+++ b/src/utils/gui_components/memchart.py
@@ -25,7 +25,7 @@
 from dash import html
 from dash_svg import G, Path, Rect, Svg, Text
 
-from utils.utils import console_error
+from utils.logger import console_error
 
 hidden_columns = ["Tips", "coll_level"]
 

--- a/src/utils/kernel_name_shortener.py
+++ b/src/utils/kernel_name_shortener.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from utils.utils import console_debug, console_error, console_log
+from utils.logger import console_debug, console_error, console_log
 
 cache = dict()
 

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -124,6 +124,7 @@ class PlainFormatter(logging.Formatter):
 # Setup console handler - provided as separate function to be called
 # prior to argument parsing
 def setup_console_handler():
+    logging.getLogger().handlers.clear()
     # register a trace level logger
     logging.TRACE = logging.DEBUG - 5
     logging.addLevelName(logging.TRACE, "TRACE")

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -41,6 +41,7 @@ COLORS = {
     "TRACE": MAGENTA,
 }
 
+
 def demarcate(function):
     def wrap_function(*args, **kwargs):
         logging.trace("----- [entering function] -> %s()" % (function.__qualname__))
@@ -49,6 +50,7 @@ def demarcate(function):
         return result
 
     return wrap_function
+
 
 def console_error(*argv, exit=True):
     if len(argv) > 1:

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -27,8 +27,6 @@ import os
 import sys
 from pathlib import Path
 
-from utils.utils import trace_logger
-
 # Define the colors
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 RESET_SEQ = "\033[0m"
@@ -42,6 +40,52 @@ COLORS = {
     "ERROR": RED,
     "TRACE": MAGENTA,
 }
+
+def demarcate(function):
+    def wrap_function(*args, **kwargs):
+        logging.trace("----- [entering function] -> %s()" % (function.__qualname__))
+        result = function(*args, **kwargs)
+        logging.trace("----- [exiting  function] -> %s()" % function.__qualname__)
+        return result
+
+    return wrap_function
+
+def console_error(*argv, exit=True):
+    if len(argv) > 1:
+        logging.error(f"[{argv[0]}] {argv[1]}")
+    else:
+        logging.error(f"{argv[0]}")
+    if exit:
+        sys.exit(1)
+
+
+def console_log(*argv, indent_level=0):
+    indent = ""
+    if indent_level >= 1:
+        indent = " " * 3 * indent_level + "|-> "  # spaces per indent level
+
+    if len(argv) > 1:
+        logging.info(indent + f"[{argv[0]}] {argv[1]}")
+    else:
+        logging.info(indent + f"{argv[0]}")
+
+
+def console_debug(*argv):
+    if len(argv) > 1:
+        logging.debug(f"[{argv[0]}] {argv[1]}")
+    else:
+        logging.debug(f"{argv[0]}")
+
+
+def console_warning(*argv):
+    if len(argv) > 1:
+        logging.warning(f"[{argv[0]}] {argv[1]}")
+    else:
+        logging.warning(f"{argv[0]}")
+
+
+def trace_logger(message, *args, **kwargs):
+    logging.log(logging.TRACE, message, *args, **kwargs)
 
 
 # Define the formatter

--- a/src/utils/mi_gpu_spec.py
+++ b/src/utils/mi_gpu_spec.py
@@ -312,7 +312,6 @@ def get_mi300_num_xcds(gpu_model_, compute_partition_):
     partition_lower = compute_partition_.lower()
 
     if gpu_model_lower not in mi300_num_xcds_dict:
-        console_log(f"Current system is not a mi300 system: {gpu_model_}")
         return None
 
     model_dict = mi300_num_xcds_dict[gpu_model_lower]

--- a/src/utils/mi_gpu_spec.py
+++ b/src/utils/mi_gpu_spec.py
@@ -1,8 +1,8 @@
-import logging
 import os
 import sys
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
+from utils.logger import console_log, console_warning, console_debug, console_error
 
 import yaml
 
@@ -96,7 +96,7 @@ class MIGPU(Singleton):
         if self.is_mi300:
             # NOTE: currently, all mi300 series gpus shall have compute partition information
             if self.compute_partition is None:
-                logging.warning(
+                console_warning(
                     "[MIGPU post init] mi300 gpu detected, but no num_xcd/compute partition data detected!!!"
                 )
 
@@ -108,7 +108,7 @@ class MIGPU(Singleton):
         All mi300 series gpus shall have compute partition information.
         """
         if num_xcds is None:
-            logging.warning(
+            console_warning(
                 "[MIGPU post init] mi300 gpu detected, but no num_xcd/compute partition data detected!!!"
             )
 
@@ -150,17 +150,17 @@ def load_yaml(file_path: str) -> Dict[str, Any]:
         Dict[str, Any]: Parsed YAML data as a nested dictionary.
                         Exit with console error if an error occurs.
     """
-    logging.debug("[load_yaml]")
+    console_debug("[load_yaml]")
     try:
         with open(file_path, "r") as file:
             data = yaml.safe_load(file)
             return data
     except FileNotFoundError:
-        logging.error(f"Error: The file '{file_path}' was not found.")
+        console_error(f"Error: The file '{file_path}' was not found.")
     except yaml.YAMLError as exc:
-        logging.error(f"Error parsing YAML file '{file_path}': {exc}")
+        console_error(f"Error parsing YAML file '{file_path}': {exc}")
     except Exception as e:
-        logging.error(
+        console_error(
             f"An unexpected error occurred while loading YAML file '{file_path}': {e}"
         )
 
@@ -186,7 +186,7 @@ def parse_mi_gpu_spec():
 
     for mi_index, mi_series in MI_CONSTANS.items():
         if mi_series != MI_CONSTANS[MI300]:
-            logging.debug("[parse_mi_gpu_spec] Processing series: %s" % mi_series)
+            console_debug("[parse_mi_gpu_spec] Processing series: %s" % mi_series)
             for key, value in yaml_data.items():
                 # parse out gpu series and gpu model information for mi50, 100, 200
                 curr_gpu_arch = value[mi_index]["gpu_archs"][0]["gpu_arch"]
@@ -235,7 +235,7 @@ def parse_mi_gpu_spec():
 
 def get_gpu_series_dict():
     if not gpu_series_dict:
-        logging.error(
+        console_error(
             "gpu_series_dict not yet populated, did you run parse_mi_gpu_spec()?"
         )
         return None
@@ -244,7 +244,7 @@ def get_gpu_series_dict():
 
 def get_gpu_series(gpu_arch_):
     if not gpu_series_dict:
-        logging.error(
+        console_error(
             "gpu_series_dict not yet populated, did you run parse_mi_gpu_spec()?"
         )
         return None
@@ -254,14 +254,14 @@ def get_gpu_series(gpu_arch_):
     if gpu_series:
         return gpu_series
 
-    logging.warning(f"No matching gpu series found for gpu arch: {gpu_arch_}")
+    console_warning(f"No matching gpu series found for gpu arch: {gpu_arch_}")
     return None
 
 
 def get_gpu_model(gpu_arch_, chip_id_):
     # Check that gpu_model_dict is populated first
     if not gpu_model_dict:
-        logging.error(
+        console_error(
             "gpu_model_dict not yet populated. Did you run parse_mi_gpu_spec()?"
         )
         return None
@@ -273,7 +273,7 @@ def get_gpu_model(gpu_arch_, chip_id_):
         if chip_id_ and int(chip_id_) in mi300_chip_id_dict:
             gpu_model = mi300_chip_id_dict.get(int(chip_id_))
         else:
-            logging.warning(f"No gpu model found for chip id: {chip_id_}")
+            console_warning(f"No gpu model found for chip id: {chip_id_}")
             return None
 
     # Otherwise use gpu_model_dict mapping for other mi architectures
@@ -281,11 +281,11 @@ def get_gpu_model(gpu_arch_, chip_id_):
         # NOTE: take the first element works for now
         gpu_model = gpu_model_dict[gpu_arch_lower][0]
     else:
-        logging.warning(f"No gpu model found for gpu arch: {gpu_arch_lower}")
+        console_warning(f"No gpu model found for gpu arch: {gpu_arch_lower}")
         return None
 
     if not gpu_model:
-        logging.warning(f"No gpu model found for gpu arch: {gpu_arch_lower}")
+        console_warning(f"No gpu model found for gpu arch: {gpu_arch_lower}")
         return None
 
     return gpu_model
@@ -293,7 +293,7 @@ def get_gpu_model(gpu_arch_, chip_id_):
 
 def get_mi300_archs_dict():
     if not mi300_archs_dict:
-        logging.error(
+        console_error(
             "mi300_archs_dict not yet populated, did you run parse_mi_gpu_spec()?"
         )
         return None
@@ -302,7 +302,7 @@ def get_mi300_archs_dict():
 
 def get_mi300_num_xcds(gpu_model_, compute_partition_):
     if not mi300_num_xcds_dict:
-        logging.error(
+        console_error(
             "mi300_num_xcds_dict not yet populated, did you run parse_mi_gpu_spec()?"
         )
         return None
@@ -311,17 +311,17 @@ def get_mi300_num_xcds(gpu_model_, compute_partition_):
     partition_lower = compute_partition_.lower()
 
     if gpu_model_lower not in mi300_num_xcds_dict:
-        logging.info(f"Current system is not a mi300 system: {gpu_model_}")
+        console_log(f"Current system is not a mi300 system: {gpu_model_}")
         return None
 
     model_dict = mi300_num_xcds_dict[gpu_model_lower]
     if partition_lower not in model_dict:
-        logging.info(f"Unknown compute partition: {compute_partition_}")
+        console_log(f"Unknown compute partition: {compute_partition_}")
         return None
 
     num_xcds = model_dict[partition_lower]
     if not num_xcds:
-        logging.warning(
+        console_warning(
             "Unknown compute partition found for %s / %s", compute_partition_, gpu_model_
         )
         return None
@@ -333,6 +333,6 @@ def get_mi300_chip_id_dict():
     if mi300_chip_id_dict:
         return mi300_chip_id_dict
     else:
-        logging.error(
+        console_error(
             "mi300_chip_id_dict not yet populated, did you run parse_mi_gpu_spec()?"
         )

--- a/src/utils/mi_gpu_spec.py
+++ b/src/utils/mi_gpu_spec.py
@@ -2,9 +2,10 @@ import os
 import sys
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
-from utils.logger import console_log, console_warning, console_debug, console_error
 
 import yaml
+
+from utils.logger import console_debug, console_error, console_log, console_warning
 
 # Constants for MI series
 # NOTE: Currently supports MI50, MI100, MI200, MI300

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -32,7 +32,7 @@ import numpy as np
 import pandas as pd
 
 from utils import schema
-from utils.utils import console_error, console_warning, demarcate
+from utils.logger import console_error, console_warning, demarcate
 
 # ------------------------------------------------------------------------------
 # Internal global definitions

--- a/src/utils/roofline_calc.py
+++ b/src/utils/roofline_calc.py
@@ -26,7 +26,7 @@ import csv
 from dataclasses import dataclass
 from pathlib import Path
 
-from utils.utils import console_debug
+from utils.logger import console_debug
 
 ################################################
 # Global vars

--- a/src/utils/specs.py
+++ b/src/utils/specs.py
@@ -38,15 +38,15 @@ from pathlib import Path as path
 import pandas as pd
 
 import config
-from utils.mi_gpu_spec import get_gpu_series_dict, get_mi300_chip_id_dict
-from utils.tty import get_table_string
-from utils.utils import get_version, total_xcds
 from utils.logger import (
     console_debug,
     console_error,
     console_log,
     console_warning,
 )
+from utils.mi_gpu_spec import get_gpu_series_dict, get_mi300_chip_id_dict
+from utils.tty import get_table_string
+from utils.utils import get_version, total_xcds
 
 VERSION_LOC = [
     "version",

--- a/src/utils/specs.py
+++ b/src/utils/specs.py
@@ -40,13 +40,12 @@ import pandas as pd
 import config
 from utils.mi_gpu_spec import get_gpu_series_dict, get_mi300_chip_id_dict
 from utils.tty import get_table_string
-from utils.utils import (
+from utils.utils import get_version, total_xcds
+from utils.logger import (
     console_debug,
     console_error,
     console_log,
     console_warning,
-    get_version,
-    total_xcds,
 )
 
 VERSION_LOC = [

--- a/src/utils/tty.py
+++ b/src/utils/tty.py
@@ -29,8 +29,8 @@ import pandas as pd
 from tabulate import tabulate
 
 from utils import parser
-from utils.utils import convert_metric_id_to_panel_idx
 from utils.logger import console_log, console_warning
+from utils.utils import convert_metric_id_to_panel_idx
 
 hidden_columns = ["Tips", "coll_level"]
 hidden_sections = [1900, 2000]

--- a/src/utils/tty.py
+++ b/src/utils/tty.py
@@ -29,7 +29,8 @@ import pandas as pd
 from tabulate import tabulate
 
 from utils import parser
-from utils.utils import console_log, console_warning, convert_metric_id_to_panel_idx
+from utils.utils import convert_metric_id_to_panel_idx
+from utils.logger import console_log, console_warning
 
 hidden_columns = ["Tips", "coll_level"]
 hidden_sections = [1900, 2000]

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -43,6 +43,7 @@ import pandas as pd
 
 import config
 from utils.mi_gpu_spec import get_mi300_num_xcds
+from utils.logger import console_error, console_debug, console_log, console_warning
 
 rocprof_cmd = ""
 rocprof_args = ""
@@ -58,54 +59,6 @@ def using_v1():
 
 def using_v3():
     return "ROCPROF" in os.environ.keys() and "rocprofv3" in os.environ["ROCPROF"]
-
-
-def demarcate(function):
-    def wrap_function(*args, **kwargs):
-        logging.trace("----- [entering function] -> %s()" % (function.__qualname__))
-        result = function(*args, **kwargs)
-        logging.trace("----- [exiting  function] -> %s()" % function.__qualname__)
-        return result
-
-    return wrap_function
-
-
-def console_error(*argv, exit=True):
-    if len(argv) > 1:
-        logging.error(f"[{argv[0]}] {argv[1]}")
-    else:
-        logging.error(f"{argv[0]}")
-    if exit:
-        sys.exit(1)
-
-
-def console_log(*argv, indent_level=0):
-    indent = ""
-    if indent_level >= 1:
-        indent = " " * 3 * indent_level + "|-> "  # spaces per indent level
-
-    if len(argv) > 1:
-        logging.info(indent + f"[{argv[0]}] {argv[1]}")
-    else:
-        logging.info(indent + f"{argv[0]}")
-
-
-def console_debug(*argv):
-    if len(argv) > 1:
-        logging.debug(f"[{argv[0]}] {argv[1]}")
-    else:
-        logging.debug(f"{argv[0]}")
-
-
-def console_warning(*argv):
-    if len(argv) > 1:
-        logging.warning(f"[{argv[0]}] {argv[1]}")
-    else:
-        logging.warning(f"{argv[0]}")
-
-
-def trace_logger(message, *args, **kwargs):
-    logging.log(logging.TRACE, message, *args, **kwargs)
 
 
 def get_version(rocprof_compute_home) -> dict:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -42,8 +42,8 @@ from pathlib import Path as path
 import pandas as pd
 
 import config
+from utils.logger import console_debug, console_error, console_log, console_warning
 from utils.mi_gpu_spec import get_mi300_num_xcds
-from utils.logger import console_error, console_debug, console_log, console_warning
 
 rocprof_cmd = ""
 rocprof_args = ""


### PR DESCRIPTION
When testing the latest `develop` branch I found that #581 uses `logging.info()` as opposed to our dedicated `console_log()` to print. If we don't use the dedicated helpers, these messages will be excluded from rocprof-computes log file and will stick out from our properly formatted outputs

![image](https://github.com/user-attachments/assets/91379ad8-a2fb-4e41-9206-befb78313863)

I see @xuchen-amd did this to avoid a circular dependency in src/utils/utils.py. I propose we move the logging helpers to the src/utils/logger.py module to avoid this circular dependency issue and ensure all file can utilize our logging helpers