### PR TITLE
External CI: add parallel mainline checks for develop and staging branches

### DIFF
--- a/.azuredevops/rocm-ci-mainline.yml
+++ b/.azuredevops/rocm-ci-mainline.yml
@@ -1,0 +1,65 @@
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - amd-mainline
+  paths:
+    exclude:
+    - .github
+    - docs
+    - '.*.y*ml'
+    - '*.md'
+    - AUTHORS
+    - LICENSE
+    - VERSION
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - amd-mainline
+  paths:
+    exclude:
+    - .github
+    - docs
+    - '.*.y*ml'
+    - '*.md'
+    - AUTHORS
+    - LICENSE
+    - VERSION
+  drafts: false
+
+# For changes to mainline, only build & test against mainline ROCm
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocprofiler-compute.yml@pipelines_repo
+    parameters:
+      jobMatrix:
+        buildJobs:
+          - gfx942-mainline:
+            name: gfx942_mainline
+            target: gfx942
+            dependencySource: mainline
+          - gfx90a-mainline:
+            name: gfx90a_mainline
+            target: gfx90a
+            dependencySource: mainline
+        testJobs:
+          - gfx942-mainline:
+            name: gfx942_mainline
+            target: gfx942
+            dependencySource: mainline
+          - gfx90a-mainline:
+            name: gfx90a_mainline
+            target: gfx90a
+            dependencySource: mainline

--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -15,7 +15,6 @@ trigger:
     include:
     - develop
     - amd-staging
-    - amd-mainline
   paths:
     exclude:
     - .github
@@ -32,7 +31,6 @@ pr:
     include:
     - develop
     - amd-staging
-    - amd-mainline
   paths:
     exclude:
     - .github
@@ -44,5 +42,6 @@ pr:
     - VERSION
   drafts: false
 
+# For changes to develop and staging, build & test against both staging and mainline ROCm
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/rocprofiler-compute.yml@pipelines_repo


### PR DESCRIPTION
The ability to run parallel staging/mainline builds was added in https://github.com/ROCm/ROCm/pull/4570. This current PR splits rocprof-compute's Azure pipeline triggers into two files, one for develop/staging and one for mainline changes. 

`rocm-ci.yml` triggers on changes to `develop` and `amd-staging` and will build+test against both staging and mainline ROCm.
[Sample run](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26402&view=results)

`rocm-ci-mainline.yml` triggers on changes to `amd-mainline` and will build+test against only mainline ROCm (same as existing behaviour).
[Sample run](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26401&view=results)