### PR TITLE
Set rocprofV3 agent-index to `absolute`

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -581,8 +581,10 @@ def run_prof(
     # standard rocprof options
     default_options = ["-i", fname]
     options = default_options + profiler_options
-    if using_v3() and path_counter_config_yaml.exists():
-        options = ["-E", str(path_counter_config_yaml)] + options
+    if using_v3():
+        options = ["-A", "absolute"] + options
+        if path_counter_config_yaml.exists():
+            options = ["-E", str(path_counter_config_yaml)] + options
 
     # set required env var for mi300
     new_env = None


### PR DESCRIPTION
By default, rocprofv3 reports Agent_Id as 'relative' values ([reference](https://github.com/ROCm/rocprofiler-sdk/blob/1f1c192a5eedd3fc59d77dd269bdc74664b7f5d3/source/docs/how-to/using-rocprofv3.rst#agent-index)). 

`v3_counter_csv_to_v2_csv` compares the reported Agent_Id against an agent's Node_Id. However, Node_Id is actually the agent's absolute ID, and Logical_Node_Id is the relative ID ([reference](https://github.com/ROCm/rocprofiler-sdk/blob/1f1c192a5eedd3fc59d77dd269bdc74664b7f5d3/source/docs/how-to/using-rocprofv3.rst#agent-info)).

If a GPU's absolute and relative IDs are different (eg. Azure CI, any Docker container where not all GPU devices are passed in), this can lead to errors when trying to convert CSVs.

Adds the `-A absolute` flag when calling rocprofv3 to resolve this.

Another way of fixing this could be replacing all Node_Id with Logical_Node_Id, though that looks more involved.