### PR TITLE
Patch in new rocprofv3 metrics.

### DIFF
--- a/src/rocprof_compute_soc/analysis_configs/gfx950/1500_TA_and_TD.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx950/1500_TA_and_TD.yaml
@@ -203,8 +203,8 @@ Panel Config:
             unit: (Instructions  + $normUnit)
             tips:
           Write Ack Instructions:
-            avg: None # AVG((TD_WRITE_ACKT_WAVEFRONT_sum / $denom))
-            min: None # MIN((TD_WRITE_ACKT_WAVEFRONT_sum / $denom))
-            max: None # MAX((TD_WRITE_ACKT_WAVEFRONT_sum / $denom))
+            avg: AVG((TD_WRITE_ACKT_WAVEFRONT_sum / $denom))
+            min: MIN((TD_WRITE_ACKT_WAVEFRONT_sum / $denom))
+            max: MAX((TD_WRITE_ACKT_WAVEFRONT_sum / $denom))
             unit: (Instructions  + $normUnit)
             tips:


### PR DESCRIPTION
Patches based on https://github.com/ROCm/rocprofiler-sdk/commit/bc85151a51b860786c280920e11e86ab4567c034
- enable `TD_WRITE_ACKT_WAVEFRONT_sum`