### PR TITLE
Implement interface to rocprofiler sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Roofline support for MI350 series architecture
 
+* Setting ROCPROF=rocprofiler-sdk environment variable will use rocprofiler-sdk C++ library instead of rocprofv3 python script
+  * Add --rocprofiler-sdk-library-path runtime option to choose the path to rocprofiler-sdk library to be used
+
 ### Changed
 
 * Change the default rocprof version to v3 when environment variable "ROCPROF" is not set

--- a/src/argparser.py
+++ b/src/argparser.py
@@ -333,6 +333,15 @@ Examples:
         help="\t\t\tSet the interval of pc sampling in microsecond (DEFAULT: 1).",
     )
 
+    profile_group.add_argument(
+        "--rocprofiler-sdk-library-path",
+        type=str,
+        dest="rocprofiler_sdk_library_path",
+        required=False,
+        default="/opt/rocm/lib/librocprofiler-sdk.so",
+        help="\t\t\tSet the path to rocprofiler SDK library.",
+    )
+
     ## Roofline Command Line Options
     roofline_group.add_argument(
         "--roof-only",

--- a/src/rocprof_compute_base.py
+++ b/src/rocprof_compute_base.py
@@ -126,17 +126,19 @@ class RocProfCompute:
             else:
                 self.__profiler_mode = "rocscope"
         else:
-            rocprof_cmd = detect_rocprof()
-            if str(rocprof_cmd).endswith("rocprof"):
+            profiler_mode = detect_rocprof(self.__args)
+            if str(profiler_mode).endswith("rocprof"):
                 self.__profiler_mode = "rocprofv1"
-            elif str(rocprof_cmd).endswith("rocprofv2"):
+            elif str(profiler_mode).endswith("rocprofv2"):
                 self.__profiler_mode = "rocprofv2"
-            elif str(rocprof_cmd).endswith("rocprofv3"):
+            elif str(profiler_mode).endswith("rocprofv3"):
                 self.__profiler_mode = "rocprofv3"
+            elif str(profiler_mode) == "rocprofiler-sdk":
+                self.__profiler_mode = "rocprofiler-sdk"
             else:
                 console_error(
                     "Incompatible profiler: %s. Supported profilers include: %s"
-                    % (rocprof_cmd, get_submodules("rocprof_compute_profile"))
+                    % (profiler_mode, get_submodules("rocprof_compute_profile"))
                 )
         return
 
@@ -300,6 +302,17 @@ class RocProfCompute:
             from rocprof_compute_profile.profiler_rocscope import rocscope_profiler
 
             profiler = rocscope_profiler(
+                self.__args,
+                self.__profiler_mode,
+                self.__soc[self.__mspec.gpu_arch],
+                self.__supported_archs,
+            )
+        elif self.__profiler_mode == "rocprofiler-sdk":
+            from rocprof_compute_profile.profiler_rocprofiler_sdk import (
+                rocprofiler_sdk_profiler,
+            )
+
+            profiler = rocprofiler_sdk_profiler(
                 self.__args,
                 self.__profiler_mode,
                 self.__soc[self.__mspec.gpu_arch],

--- a/src/rocprof_compute_profile/profiler_base.py
+++ b/src/rocprof_compute_profile/profiler_base.py
@@ -416,6 +416,7 @@ class RocProfCompute_Base:
                 self.__profiler == "rocprofv1"
                 or self.__profiler == "rocprofv2"
                 or self.__profiler == "rocprofv3"
+                or self.__profiler == "rocprofiler-sdk"
             ):
                 start_run_prof = time.time()
                 run_prof(
@@ -441,12 +442,16 @@ class RocProfCompute_Base:
                 # TODO: Finish logic
                 console_error("Profiler not supported")
 
-        if self.__pc_sampling == True and self.__profiler == "rocprofv3":
+        if self.__pc_sampling == True and self.__profiler in (
+            "rocprofv3",
+            "rocprofiler-sdk",
+        ):
             start_run_prof = time.time()
             pc_sampling_prof(
                 interval=self.get_args().pc_sampling_interval,
                 workload_dir=self.get_args().path,
                 appcmd=self.get_args().remaining,
+                rocprofiler_sdk_library_path=self.get_args().rocprofiler_sdk_library_path,
             )
             end_run_prof = time.time()
             console_debug(

--- a/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -1,0 +1,126 @@
+##############################################################################bl
+# MIT License
+#
+# Copyright (c) 2021 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+##############################################################################el
+
+import os
+import shlex
+from pathlib import Path
+
+from rocprof_compute_profile.profiler_base import RocProfCompute_Base
+from utils.logger import console_error, console_log, demarcate
+
+
+class rocprofiler_sdk_profiler(RocProfCompute_Base):
+    def __init__(self, profiling_args, profiler_mode, soc, supported_archs):
+        super().__init__(profiling_args, profiler_mode, soc, supported_archs)
+        self.ready_to_profile = (
+            self.get_args().roof_only
+            and not Path(self.get_args().path).joinpath("pmc_perf.csv").is_file()
+            or not self.get_args().roof_only
+        )
+
+    def get_profiler_options(self, fname, soc):
+        app_cmd = shlex.split(self.get_args().remaining)
+        rocm_libdir = str(Path(self.get_args().rocprofiler_sdk_library_path).parent)
+        rocprofiler_sdk_tool_path = str(
+            Path(rocm_libdir).joinpath("rocprofiler-sdk/librocprofiler-sdk-tool.so")
+        )
+        ld_preload = [
+            rocprofiler_sdk_tool_path,
+            self.get_args().rocprofiler_sdk_library_path,
+        ]
+        options = {
+            "ROCPROFILER_LIBRARY_CTOR": "1",
+            "LD_PRELOAD": ":".join(ld_preload),
+            "ROCP_TOOL_LIBRARIES": rocprofiler_sdk_tool_path,
+            "LD_LIBRARY_PATH": rocm_libdir,
+            "ROCPROF_KERNEL_TRACE": "1",
+            "ROCPROF_OUTPUT_FORMAT": "json",
+            "ROCPROF_OUTPUT_PATH": self.get_args().path + "/out/pmc_1",
+        }
+
+        if self.get_args().format_rocprof_output == "csv":
+            options["ROCPROF_OUTPUT_FORMAT"] = "csv"
+
+        if self.get_args().kokkos_trace:
+            # NOTE: --kokkos-trace feature is incomplete and is disabled for now.
+            console_error(
+                "The option '--kokkos-trace' is not supported in the current version of rocprof-compute. This functionality is planned for a future release. Please adjust your profiling options accordingly."
+            )
+        if self.get_args().hip_trace:
+            options["ROCPROF_HIP_COMPILER_API_TRACE"] = "1"
+            options["ROCPROF_HIP_RUNTIME_API_TRACE"] = "1"
+
+        # Kernel filtering
+        if self.get_args().kernel:
+            options["ROCPROF_KERNEL_FILTER_INCLUDE_REGEX"] = "|".join(
+                self.get_args().kernel
+            )
+        # Dispatch filtering
+        dispatch = []
+        # rocprof sdk dispatch indexing is inclusive and starts from 1
+        if self.get_args().dispatch:
+            for dispatch_id in self.get_args().dispatch:
+                if ":" in dispatch_id:
+                    tokens = dispatch_id.split(":")
+                    # 4:7 -> 5-7
+                    dispatch.append(f"{int(tokens[0]) + 1}-{tokens[1]}")
+                else:
+                    # 4 -> 5
+                    dispatch.append(f"{int(dispatch_id) + 1}")
+        if dispatch:
+            options["ROCPROF_KERNEL_FILTER_RANGE"] = f"[{','.join(dispatch)}]"
+        options["APP_CMD"] = app_cmd
+        return options
+
+    # -----------------------
+    # Required child methods
+    # -----------------------
+    @demarcate
+    def pre_processing(self):
+        """Perform any pre-processing steps prior to profiling."""
+        super().pre_processing()
+
+    @demarcate
+    def run_profiling(self, version, prog):
+        """Run profiling."""
+        if self.ready_to_profile:
+            if self.get_args().roof_only:
+                console_log(
+                    "roofline", "Generating pmc_perf.csv (roofline counters only)."
+                )
+            # Log profiling options and setup filtering
+            super().run_profiling(version, prog)
+        else:
+            console_log("roofline", "Detected existing pmc_perf.csv")
+
+    @demarcate
+    def post_processing(self):
+        """Perform any post-processing steps prior to profiling."""
+        super().post_processing()
+
+        if self.ready_to_profile:
+            # Manually join each pmc_perf*.csv output
+            self.join_prof()
+            # Replace timestamp data to solve a known rocprof bug
+            # replace_timestamps(self.get_args().path)

--- a/src/rocprof_compute_soc/soc_gfx908.py
+++ b/src/rocprof_compute_soc/soc_gfx908.py
@@ -33,7 +33,9 @@ class gfx908_soc(OmniSoC_Base):
     def __init__(self, args, mspec):
         super().__init__(args, mspec)
         self.set_arch("gfx908")
-        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv3"])
+        self.set_compatible_profilers(
+            ["rocprofv1", "rocscope", "rocprofv3", "rocprofiler-sdk"]
+        )
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx90a.py
+++ b/src/rocprof_compute_soc/soc_gfx90a.py
@@ -46,7 +46,9 @@ class gfx90a_soc(OmniSoC_Base):
                     )
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2", "rocprofv3"])
+        self.set_compatible_profilers(
+            ["rocprofv1", "rocscope", "rocprofv2", "rocprofv3", "rocprofiler-sdk"]
+        )
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx940.py
+++ b/src/rocprof_compute_soc/soc_gfx940.py
@@ -46,7 +46,9 @@ class gfx940_soc(OmniSoC_Base):
                     )
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocprofv2", "rocprofv3"])
+        self.set_compatible_profilers(
+            ["rocprofv1", "rocprofv2", "rocprofv3", "rocprofiler-sdk"]
+        )
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx941.py
+++ b/src/rocprof_compute_soc/soc_gfx941.py
@@ -46,7 +46,9 @@ class gfx941_soc(OmniSoC_Base):
                     )
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocprofv2", "rocprofv3"])
+        self.set_compatible_profilers(
+            ["rocprofv1", "rocprofv2", "rocprofv3", "rocprofiler-sdk"]
+        )
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx942.py
+++ b/src/rocprof_compute_soc/soc_gfx942.py
@@ -46,7 +46,9 @@ class gfx942_soc(OmniSoC_Base):
                     )
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocprofv2", "rocprofv3"])
+        self.set_compatible_profilers(
+            ["rocprofv1", "rocprofv2", "rocprofv3", "rocprofiler-sdk"]
+        )
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/rocprof_compute_soc/soc_gfx950.py
+++ b/src/rocprof_compute_soc/soc_gfx950.py
@@ -46,7 +46,7 @@ class gfx950_soc(OmniSoC_Base):
                     )
                 )
             )
-        self.set_compatible_profilers(["rocprofv3"])
+        self.set_compatible_profilers(["rocprofv3", "rocprofiler-sdk"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -1181,7 +1181,7 @@ def load_pc_sampling_data(workload, dir, file_prefix):
 
     # No kernel filter, return grouped and sorted csv directly
     if not workload.filter_kernel_ids:
-        # NB: the default file name is subject to changes from rocprofv3
+        # NB: the default file name is subject to changes from rocprofv3/rocprofiler_sdk
         csv_file_path = Path.joinpath(
             Path(dir), file_prefix + "_pc_sampling_host_trap.csv"
         )
@@ -1221,7 +1221,7 @@ def load_pc_sampling_data(workload, dir, file_prefix):
 
     elif len(workload.filter_kernel_ids) == 1:
         # print("kernel id", workload.filter_kernel_ids[0])
-        # NB: the default file name is subject to changes from rocprofv3
+        # NB: the default file name is subject to changes from rocprofv3/rocprofiler_sdk
         json_file_path = Path.joinpath(Path(dir), file_prefix + "_results.json")
         if not json_file_path.exists():
             console_error("PC sampling: can not read %s " % json_file_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,26 @@ def pytest_addoption(parser):
         help="Call standalone binary instead of main function during tests",
     )
 
+    parser.addoption(
+        "--rocprofiler-sdk-library-path",
+        type=str,
+        default="/opt/rocm/lib/librocprofiler-sdk.so",
+        help="Path to the rocprofiler-sdk library",
+    )
+
 
 @pytest.fixture
 def binary_handler_profile_rocprof_compute(request):
     def _handler(
         config, workload_dir, options=[], check_success=True, roof=False, app_name="app_1"
     ):
+        if request.config.getoption("--rocprofiler-sdk-library-path"):
+            options.extend(
+                [
+                    "--rocprofiler-sdk-library-path",
+                    request.config.getoption("--rocprofiler-sdk-library-path"),
+                ],
+            )
         if request.config.getoption("--call-binary"):
             baseline_opts = [
                 "build/rocprof-compute.bin",

--- a/tests/test_profile_general.py
+++ b/tests/test_profile_general.py
@@ -323,15 +323,22 @@ def gpu_soc():
 soc = gpu_soc()
 
 # Set rocprofv2 as profiler if MI300
-if soc == "MI100":
-    os.environ["ROCPROF"] = "rocprof"
+if "ROCPROF" not in os.environ.keys():
+    if soc == "MI100":
+        os.environ["ROCPROF"] = "rocprof"
 
-else:
-    os.environ["ROCPROF"] = "rocprofv3"
+    else:
+        os.environ["ROCPROF"] = "rocprofv3"
 
 
 def using_v3():
-    return "ROCPROF" in os.environ.keys() and os.environ["ROCPROF"].endswith("rocprofv3")
+    return "ROCPROF" not in os.environ.keys() or (
+        "ROCPROF" in os.environ.keys()
+        and (
+            os.environ["ROCPROF"].endswith("rocprofv3")
+            or os.environ["ROCPROF"] == "rocprofiler-sdk"
+        )
+    )
 
 
 Baseline_dir = str(Path("tests/workloads/vcopy/" + soc).resolve())


### PR DESCRIPTION
Implement interface to rocprofiler sdk

  * Add profiler mode = rocprofiler-sdk which will not invoke rocprofv3 but use rocprofiler-sdk directly, this can be selected by setting env. var. ROCPROF=rocprofiler-sdk
  
  * Add runtime option --rocprofiler-sdk-library-path to use custom version of rocprofiler sdk library
      * Add --rocprofiler-sdk-library-path conftest option for tests
  
  * Setup appropriate environment variables to inject rocprofiler sdk code to user command
      * Add env. vars. for counter collection and filtering
      * Add env. vars. for pc sampling
   
  * Use python bindings to list counters supported by rocprofiler sdk

  * Update changelog