### PR TITLE
Fix roofline-data-type populating in both profile and analyze modes

### DIFF
--- a/src/rocprof_compute_analyze/analysis_webui.py
+++ b/src/rocprof_compute_analyze/analysis_webui.py
@@ -61,8 +61,7 @@ class webui_analysis(OmniAnalyze_Base):
         # define any elements which will have full width
         self.__full_width_elements = {1801}
 
-        if hasattr(args, "roofline_data_type") and args.roofline_data_type != ["FP32"]:
-            self.__roofline_data_type = args.roofline_data_type
+        self.__roofline_data_type = args.roofline_data_type
 
     @demarcate
     def build_layout(self, input_filters, arch_configs):

--- a/src/roofline.py
+++ b/src/roofline.py
@@ -60,7 +60,6 @@ class Roofline:
                 "mem_level": "ALL",
                 "include_kernel_names": False,
                 "is_standalone": False,
-                "roofline_data_type": ["FP32"],
             }
         )
         self.__ai_data = None
@@ -77,10 +76,7 @@ class Roofline:
             self.__run_parameters["mem_level"] = self.__args.mem_level
         if hasattr(self.__args, "sort") and self.__args.sort != "ALL":
             self.__run_parameters["sort_type"] = self.__args.sort
-        if hasattr(
-            self.__args, "roofline_data_type"
-        ) and self.__args.roofline_data_type != ["FP32"]:
-            self.__run_parameters["roofline_data_type"] = self.__args.roofline_data_type
+        self.__run_parameters["roofline_data_type"] = self.__args.roofline_data_type
         self.validate_parameters()
 
     def validate_parameters(self):


### PR DESCRIPTION
Original issue was that GUI in analyze mode does not generate roofline without error. Roofline-data-type option was not populating the default option in same way as profile mode.
After reviewing how the add_arg and run parameters get populated it is safe to remove the hasattr checks since we will always be populating roofline_data_type with either the user args (which are also checked for validity) or the default FP32. The check here was the main issue preventing default from populating; there will never be a case that roofline-data-type is empty so we can remove this fully.

Verified both profile mode and analyze mode, providing roofline-data-type option and without (to verify defaults to FP32), on an MI300X system.