### PR TITLE
Update illegal character check on profile name

### DIFF
--- a/src/rocprof_compute_base.py
+++ b/src/rocprof_compute_base.py
@@ -252,6 +252,9 @@ class RocProfCompute:
         elif self.__args.name is None:
             sys.exit("Either --list-name or --name is required")
 
+        if self.__args.name.find("/") != -1:
+            console_error("'/' not permitted in profile name")
+
         # Deprecation warning for hardware blocks
         if [
             name

--- a/src/rocprof_compute_profile/profiler_base.py
+++ b/src/rocprof_compute_profile/profiler_base.py
@@ -308,12 +308,6 @@ class RocProfCompute_Base:
                 "Profiling command required. Pass application executable after -- at the end of options.\n\t\ti.e. rocprof-compute profile -n vcopy -- ./vcopy -n 1048576 -b 256"
             )
 
-        # verify name meets MongoDB length requirements and no illegal chars
-        if len(self.__args.name) > 35:
-            console_error("-n/--name exceeds 35 character limit. Try again.")
-        if self.__args.name.find(".") != -1 or self.__args.name.find("-") != -1:
-            console_error("'-' and '.' are not permitted in -n/--name")
-
         gen_sysinfo(
             workload_name=self.__args.name,
             workload_dir=self.get_args().path,


### PR DESCRIPTION
- Remove restriction on dot (.) and dash (-) in profile names
- Add restriction on forward slash (/) in profile name
- Move profile name check to beginning of program before directory is created. Previously we were creating the directory and then checking the name.