### PR TITLE
Check mode during soc init

### DIFF
--- a/src/rocprof_compute_soc/soc_gfx90a.py
+++ b/src/rocprof_compute_soc/soc_gfx90a.py
@@ -64,7 +64,9 @@ class gfx90a_soc(OmniSoC_Base):
                 "GDS": 4,
             }
         )
-        self.roofline_obj = Roofline(args, self._mspec)
+        # Create roofline object if mode is provided; skip for --specs
+        if hasattr(self.get_args(), "mode") and self.get_args().mode:
+            self.roofline_obj = Roofline(args, self._mspec)
 
         # Set arch specific specs
         self._mspec._l2_banks = 32

--- a/src/rocprof_compute_soc/soc_gfx940.py
+++ b/src/rocprof_compute_soc/soc_gfx940.py
@@ -64,7 +64,9 @@ class gfx940_soc(OmniSoC_Base):
                 "GDS": 4,
             }
         )
-        self.roofline_obj = Roofline(args, self._mspec)
+        # Create roofline object if mode is provided; skip for --specs
+        if hasattr(self.get_args(), "mode") and self.get_args().mode:
+            self.roofline_obj = Roofline(args, self._mspec)
 
         # Set arch specific specs
         self._mspec._l2_banks = 16

--- a/src/rocprof_compute_soc/soc_gfx941.py
+++ b/src/rocprof_compute_soc/soc_gfx941.py
@@ -64,7 +64,9 @@ class gfx941_soc(OmniSoC_Base):
                 "GDS": 4,
             }
         )
-        self.roofline_obj = Roofline(args, self._mspec)
+        # Create roofline object if mode is provided; skip for --specs
+        if hasattr(self.get_args(), "mode") and self.get_args().mode:
+            self.roofline_obj = Roofline(args, self._mspec)
 
         # Set arch specific specs
         self._mspec._l2_banks = 16

--- a/src/rocprof_compute_soc/soc_gfx942.py
+++ b/src/rocprof_compute_soc/soc_gfx942.py
@@ -64,7 +64,9 @@ class gfx942_soc(OmniSoC_Base):
                 "GDS": 4,
             }
         )
-        self.roofline_obj = Roofline(args, self._mspec)
+        # Create roofline object if mode is provided; skip for --specs
+        if hasattr(self.get_args(), "mode") and self.get_args().mode:
+            self.roofline_obj = Roofline(args, self._mspec)
 
         # Set arch specific specs
         self._mspec._l2_banks = 16

--- a/src/rocprof_compute_soc/soc_gfx950.py
+++ b/src/rocprof_compute_soc/soc_gfx950.py
@@ -63,7 +63,9 @@ class gfx950_soc(OmniSoC_Base):
                 "TCC_channels": 16,
             }
         )
-        self.roofline_obj = Roofline(args, self._mspec)
+        # Create roofline object if mode is provided; skip for --specs
+        if hasattr(self.get_args(), "mode") and self.get_args().mode:
+            self.roofline_obj = Roofline(args, self._mspec)
 
         # Set arch specific specs
         self._mspec._l2_banks = 16


### PR DESCRIPTION
Prevent roofline object creation if there is no mode (profile, analyze, database) provided- in short, skip if only printing specs.