### PR TITLE
Fix MI350 tests

### DIFF
--- a/tests/test_profile_general.py
+++ b/tests/test_profile_general.py
@@ -125,6 +125,13 @@ ALL_CSVS_MI350 = sorted(
         "pmc_perf_5.csv",
         "pmc_perf_6.csv",
         "pmc_perf_7.csv",
+        "pmc_perf_8.csv",
+        "pmc_perf_9.csv",
+        "pmc_perf_10.csv",
+        "pmc_perf_11.csv",
+        "pmc_perf_12.csv",
+        "pmc_perf_13.csv",
+        "pmc_perf_14.csv",
         "sysinfo.csv",
     ]
 )
@@ -733,6 +740,7 @@ def test_block_SQ(binary_handler_profile_rocprof_compute):
             "pmc_perf_5.csv",
             "pmc_perf_6.csv",
             "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
             "sysinfo.csv",
         ]
 
@@ -762,7 +770,7 @@ def test_block_SQC(binary_handler_profile_rocprof_compute):
         "sysinfo.csv",
         "timestamps.csv",
     ]
-    if using_v3() or soc == "MI350":
+    if using_v3():
         expected_csvs.remove("timestamps.csv")
 
     assert sorted(list(file_dict.keys())) == sorted(expected_csvs)
@@ -796,8 +804,25 @@ def test_block_TA(binary_handler_profile_rocprof_compute):
         "sysinfo.csv",
         "timestamps.csv",
     ]
-    if using_v3() or soc == "MI350":
+
+    if using_v3():
         expected_csvs.remove("timestamps.csv")
+
+    if soc == "MI350":
+        expected_csvs = [
+            "pmc_perf.csv",
+            "pmc_perf_0.csv",
+            "pmc_perf_1.csv",
+            "pmc_perf_2.csv",
+            "pmc_perf_3.csv",
+            "pmc_perf_4.csv",
+            "pmc_perf_5.csv",
+            "pmc_perf_6.csv",
+            "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
+            "pmc_perf_9.csv",
+            "sysinfo.csv",
+        ]
 
     assert sorted(list(file_dict.keys())) == sorted(expected_csvs)
 
@@ -902,6 +927,26 @@ def test_block_TCP(binary_handler_profile_rocprof_compute):
             "sysinfo.csv",
         ]
 
+    if soc == "MI350":
+        expected_csvs = [
+            "pmc_perf.csv",
+            "pmc_perf_0.csv",
+            "pmc_perf_1.csv",
+            "pmc_perf_2.csv",
+            "pmc_perf_3.csv",
+            "pmc_perf_4.csv",
+            "pmc_perf_5.csv",
+            "pmc_perf_6.csv",
+            "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
+            "pmc_perf_9.csv",
+            "pmc_perf_10.csv",
+            "pmc_perf_11.csv",
+            "pmc_perf_12.csv",
+            "pmc_perf_13.csv",
+            "sysinfo.csv",
+        ]
+
     if soc == "MI100" or soc == "MI200":
         expected_csvs = [
             "pmc_perf.csv",
@@ -934,9 +979,6 @@ def test_block_TCP(binary_handler_profile_rocprof_compute):
                 "pmc_perf_9.csv",
                 "sysinfo.csv",
             ]
-
-    if soc == "MI350":
-        expected_csvs.remove("timestamps.csv")
 
     assert sorted(list(file_dict.keys())) == sorted(expected_csvs)
 
@@ -992,6 +1034,32 @@ def test_block_TCC(binary_handler_profile_rocprof_compute):
             "sysinfo.csv",
         ]
 
+    if soc == "MI350":
+        expected_csvs = [
+            "pmc_perf.csv",
+            "pmc_perf_0.csv",
+            "pmc_perf_1.csv",
+            "pmc_perf_2.csv",
+            "pmc_perf_3.csv",
+            "pmc_perf_4.csv",
+            "pmc_perf_5.csv",
+            "pmc_perf_6.csv",
+            "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
+            "pmc_perf_9.csv",
+            "pmc_perf_10.csv",
+            "pmc_perf_11.csv",
+            "pmc_perf_12.csv",
+            "pmc_perf_13.csv",
+            "pmc_perf_14.csv",
+            "pmc_perf_15.csv",
+            "pmc_perf_16.csv",
+            "pmc_perf_17.csv",
+            "pmc_perf_18.csv",
+            "pmc_perf_19.csv",
+            "sysinfo.csv",
+        ]
+
     if soc == "MI100" or soc == "MI200":
         expected_csvs = [
             "pmc_perf.csv",
@@ -1026,9 +1094,6 @@ def test_block_TCC(binary_handler_profile_rocprof_compute):
                 "pmc_perf_10.csv",
                 "sysinfo.csv",
             ]
-
-    if soc == "MI350":
-        expected_csvs.remove("timestamps.csv")
 
     assert sorted(list(file_dict.keys())) == sorted(expected_csvs)
 
@@ -1091,6 +1156,7 @@ def test_block_SPI(binary_handler_profile_rocprof_compute):
             "pmc_perf_9.csv",
             "pmc_perf_10.csv",
             "pmc_perf_11.csv",
+            "pmc_perf_12.csv",
             "sysinfo.csv",
         ]
 
@@ -1171,7 +1237,7 @@ def test_block_CPF(binary_handler_profile_rocprof_compute):
         "sysinfo.csv",
         "timestamps.csv",
     ]
-    if using_v3() or soc == "MI350":
+    if using_v3():
         expected_csvs.remove("timestamps.csv")
     assert sorted(list(file_dict.keys())) == sorted(expected_csvs)
 
@@ -1257,6 +1323,7 @@ def test_block_SQ_CPC(binary_handler_profile_rocprof_compute):
             "pmc_perf_5.csv",
             "pmc_perf_6.csv",
             "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
             "sysinfo.csv",
         ]
 
@@ -1344,6 +1411,7 @@ def test_block_SQ_TA(binary_handler_profile_rocprof_compute):
             "pmc_perf_5.csv",
             "pmc_perf_6.csv",
             "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
             "sysinfo.csv",
         ]
 
@@ -1427,6 +1495,7 @@ def test_block_SQ_SPI(binary_handler_profile_rocprof_compute):
             "pmc_perf_5.csv",
             "pmc_perf_6.csv",
             "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
             "sysinfo.csv",
         ]
 
@@ -1515,6 +1584,7 @@ def test_block_SQ_SQC_TCP_CPC(binary_handler_profile_rocprof_compute):
             "pmc_perf_5.csv",
             "pmc_perf_6.csv",
             "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
             "sysinfo.csv",
         ]
 
@@ -1617,6 +1687,13 @@ def test_block_SQ_SPI_TA_TCC_CPF(binary_handler_profile_rocprof_compute):
             "pmc_perf_5.csv",
             "pmc_perf_6.csv",
             "pmc_perf_7.csv",
+            "pmc_perf_8.csv",
+            "pmc_perf_9.csv",
+            "pmc_perf_10.csv",
+            "pmc_perf_11.csv",
+            "pmc_perf_12.csv",
+            "pmc_perf_13.csv",
+            "pmc_perf_14.csv",
             "sysinfo.csv",
         ]
 


### PR DESCRIPTION
- TCC counter collection tests are still failing due to recent rocprofiler-sdk change