### PR TITLE
Add SQLite3 package to test docker container

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 RUN git config --global --add safe.directory /app
 
 # Install Python 3.10 and pip
-RUN apt-get install -y python3.10 python3.10-venv python3.10-dev python3-pip
+RUN apt-get install -y python3.10 python3.10-venv python3.10-dev python3-pip libsqlite3-dev
 
 # Set Python 3.10 as the default python3
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1


### PR DESCRIPTION
Add SQLite3 package to test docker container to be able to build rocprofiler-sdk.

This is required due to https://github.com/ROCm/rocprofiler-sdk/commit/7afedc63be9a87ec7284ef0270d93bb2d0d24358 where rocprofiler-sdk default output was changed to sql database instead of a csv files