### PR TITLE
Revert default interface to rocprof v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,15 +55,15 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Roofline support for MI350 series architecture
 
-* Setting ROCPROF=rocprofiler-sdk environment variable will use rocprofiler-sdk C++ library instead of rocprofv3 python script
+* Interface to rocprofiler-sdk
+  * Setting ROCPROF=rocprofiler-sdk environment variable will use rocprofiler-sdk C++ library instead of rocprofv3 python script
   * Add --rocprofiler-sdk-library-path runtime option to choose the path to rocprofiler-sdk library to be used
+  * Using rocprof v1 / v2 / v3 interfaces will trigger a deprecation warning to use rocprofiler-sdk interface
 
 * Support MEM chart on CLI(single run)
 
 ### Changed
 
-* Change the default rocprof version to v3 when environment variable "ROCPROF" is not set
-* Change the rocprof version for unit tests to rocprofv3 on all SoCs except MI100
 * Change normal_unit default to per_kernel
 * Change dependency from rocm-smi to amd-smi
 * Decrease profiling time by not collecting counters not used in post analysis

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -312,9 +312,18 @@ def detect_rocprof(args):
         )
         return rocprof_cmd
 
+    console_warning(
+        "rocprof v1 / v2 / v3 interfaces will be deprecated in favor of "
+        "rocprofiler-sdk interface in a future release. To use rocprofiler-sdk "
+        "interface, please set the environment variable ROCPROF to 'rocprofiler-sdk' "
+        "and optionally provide the path to librocprofiler-sdk.so library via the "
+        "--rocprofiler-sdk-library-path option."
+    )
+
     # detect rocprof
     if not "ROCPROF" in os.environ.keys():
-        rocprof_cmd = "rocprofv3"
+        # default rocprof
+        rocprof_cmd = "rocprof"
     else:
         rocprof_cmd = os.environ["ROCPROF"]
 


### PR DESCRIPTION
* Add deprecation warning for rocprof v1 / v2 / v3 interfaces to use rocprofiler-sdk interface