### PR TITLE
Fix load_kernel_top arg for GUI analyze mode

### DIFF
--- a/src/rocprof_compute_analyze/analysis_webui.py
+++ b/src/rocprof_compute_analyze/analysis_webui.py
@@ -315,7 +315,9 @@ class webui_analysis(OmniAnalyze_Base):
                 kernel_verbose=self.get_args().kernel_verbose,
             )
             # create the loaded kernel stats
-            parser.load_kernel_top(self._runs[self.dest_dir], self.dest_dir)
+            parser.load_kernel_top(
+                self._runs[self.dest_dir], self.dest_dir, self.get_args()
+            )
             # set architecture
             self.arch = self._runs[self.dest_dir].sys_info.iloc[0]["gpu_arch"]
 


### PR DESCRIPTION
--gui option for analyze mode failing due to missing arg in load_kernel_top call in pre_processing
Manually tested --gui option to confirm fix. This change does not affect regular analyze run, only gui mode option.