### PR TITLE
Fix: Add explicit includes for assert.h and thread in sample/vcopy.cpp

### DIFF
--- a/sample/vcopy.cpp
+++ b/sample/vcopy.cpp
@@ -25,6 +25,8 @@
 */
 
 #include "hip/hip_runtime.h"
+#include <assert.h>
+#include <thread>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/sample/vrandom_access.cpp
+++ b/sample/vrandom_access.cpp
@@ -30,6 +30,7 @@ An example code to execute random access to explore cache hits/misses in L2 Cach
 
 
 #include <hip/hip_runtime.h>
+#include <assert.h>
 #include <iostream>
 #include <cstdlib>
 #include <ctime>

--- a/sample/vsequential_access.cpp
+++ b/sample/vsequential_access.cpp
@@ -32,7 +32,6 @@ An example code to execute sequential access to explore cache hits/misses in L2 
 #include <hip/hip_runtime.h>
 #include <iostream>
 #include <assert.h>
-#include <thread>
 
 #define HIP_ASSERT(x) (assert((x)==hipSuccess))
 

--- a/sample/vsequential_access.cpp
+++ b/sample/vsequential_access.cpp
@@ -31,6 +31,8 @@ An example code to execute sequential access to explore cache hits/misses in L2 
 
 #include <hip/hip_runtime.h>
 #include <iostream>
+#include <assert.h>
+#include <thread>
 
 #define HIP_ASSERT(x) (assert((x)==hipSuccess))
 


### PR DESCRIPTION
The HIP/CLR change e3cb5399c removed transitive inclusion   of standard headers like assert.h from hip_runtime.h.   This caused build failures in rocprof-compute samples.  

This commit explicitly includes <assert.h> and <thread>   in vcopy.cpp to resolve potential missing definitions.