### PR TITLE
Print counter list in DEBUG level

### DIFF
--- a/src/rocprof_compute_soc/soc_base.py
+++ b/src/rocprof_compute_soc/soc_base.py
@@ -610,7 +610,7 @@ class OmniSoC_Base:
                 "No performance counters to collect, please check the provided profiling filters",
             )
         else:
-            console_log(f"Collecting following counters: {', '.join(counters)} ")
+            console_debug(f"Collecting following counters: {', '.join(counters)} ")
 
         output_files = []
 


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->

Currently the output of rocprofiler compute is too long due to the list of counters being printed by default.
In this PR we are moving the log level of list of counters being printed from INFO to DEBUG such that they will only be printed when --verbose option is given.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
