### PR TITLE
Documentation update for FP8 on MI300

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ set(PYTEST_NUMPROCS
     CACHE STRING "Number of parallel threads to use with CPU-oriented tests")
 message(STATUS "Pytest CPU threadcount: ${PYTEST_NUMPROCS}")
 
-#2 CPU threads available for testing(test-analyze-commands)
+# 2 CPU threads available for testing(test-analyze-commands)
 set(PYTEST_NUMPROCS_ANALYSIS
     "4"
     CACHE STRING "Number of parallel threads to use with CPU-oriented tests")
@@ -275,8 +275,8 @@ set_tests_properties(
 add_test(
     NAME test_analyze_commands
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS_ANALYSIS}
-          --verbose --junitxml=tests/test_analyze_commands.xml ${COV_OPTION}
+        ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS_ANALYSIS} --verbose
+        --junitxml=tests/test_analyze_commands.xml ${COV_OPTION}
         ${PROJECT_SOURCE_DIR}/tests/test_analyze_commands.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 

--- a/docs/conceptual/pipeline-metrics.rst
+++ b/docs/conceptual/pipeline-metrics.rst
@@ -522,7 +522,7 @@ MFMA instructions are classified by the type of input data they operate on, and
    * - MFMA-F8 Instructions
 
      - The total number of 8-bit floating point :ref:`MFMA <desc-mfma>`
-       instructions issued per :ref:`normalization unit <normalization-units>`. (Instinct MI300 series and later only)
+       instructions issued per :ref:`normalization unit <normalization-units>`. This is supported in AMD Instinct MI300 series and later only.
 
      - Instructions per :ref:`normalization unit <normalization-units>`
 

--- a/docs/conceptual/pipeline-metrics.rst
+++ b/docs/conceptual/pipeline-metrics.rst
@@ -522,7 +522,7 @@ MFMA instructions are classified by the type of input data they operate on, and
    * - MFMA-F8 Instructions
 
      - The total number of 8-bit floating point :ref:`MFMA <desc-mfma>`
-       instructions issued per :ref:`normalization unit <normalization-units>`. (MI300 and the above only)
+       instructions issued per :ref:`normalization unit <normalization-units>`. (Instinct MI300 series and later only)
 
      - Instructions per :ref:`normalization unit <normalization-units>`
 

--- a/docs/conceptual/pipeline-metrics.rst
+++ b/docs/conceptual/pipeline-metrics.rst
@@ -519,6 +519,13 @@ MFMA instructions are classified by the type of input data they operate on, and
 
      - Instructions per :ref:`normalization unit <normalization-units>`
 
+   * - MFMA-F8 Instructions
+
+     - The total number of 8-bit floating point :ref:`MFMA <desc-mfma>`
+       instructions issued per :ref:`normalization unit <normalization-units>`. (MI300 and the above only)
+
+     - Instructions per :ref:`normalization unit <normalization-units>`
+
    * - MFMA-F16 Instructions
 
      - The total number of 16-bit floating point :ref:`MFMA <desc-mfma>`

--- a/docs/conceptual/system-speed-of-light.rst
+++ b/docs/conceptual/system-speed-of-light.rst
@@ -49,6 +49,16 @@ of ROCm Compute Profiler’s profiling report.
 
      - GIOPs
 
+   * - :ref:`MFMA <desc-mfma>` FLOPs (F8)
+
+     - The total number of 8-bit floating point :ref:`MFMA <desc-mfma>`
+       operations executed per second. Note: this does not include any 16-bit
+       brain floating point operations from :ref:`VALU <desc-valu>`
+       instructions. This is also presented as a percent of the peak theoretical
+       F8 MFMA operations achievable on the specific accelerator. (MI300 and the above only)
+
+     - GFLOPs
+
    * - :ref:`MFMA <desc-mfma>` FLOPs (BF16)
 
      - The total number of 16-bit brain floating point :ref:`MFMA <desc-mfma>`

--- a/docs/conceptual/system-speed-of-light.rst
+++ b/docs/conceptual/system-speed-of-light.rst
@@ -55,7 +55,7 @@ of ROCm Compute Profiler’s profiling report.
        operations executed per second. Note: this does not include any 16-bit
        brain floating point operations from :ref:`VALU <desc-valu>`
        instructions. This is also presented as a percent of the peak theoretical
-       F8 MFMA operations achievable on the specific accelerator. (MI300 and the above only)
+       F8 MFMA operations achievable on the specific accelerator. (Instinct MI300 series and later only)
 
      - GFLOPs
 

--- a/docs/conceptual/system-speed-of-light.rst
+++ b/docs/conceptual/system-speed-of-light.rst
@@ -52,10 +52,10 @@ of ROCm Compute Profiler’s profiling report.
    * - :ref:`MFMA <desc-mfma>` FLOPs (F8)
 
      - The total number of 8-bit floating point :ref:`MFMA <desc-mfma>`
-       operations executed per second. Note: this does not include any 16-bit
+       operations executed per second. This does not include any 16-bit
        brain floating point operations from :ref:`VALU <desc-valu>`
        instructions. This is also presented as a percent of the peak theoretical
-       F8 MFMA operations achievable on the specific accelerator. (Instinct MI300 series and later only)
+       F8 MFMA operations achievable on the specific accelerator. It is supported on AMD Instinct MI300 series and later only.
 
      - GFLOPs
 


### PR DESCRIPTION
# rocprofiler-compute Pull Request

This is an urgent ask for ROCm 6.4.2 release: Doc team asks a quick doc ref for FP8 on MI300. This is not the long term solution.

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [x] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [x] Yes
- [ ] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
