### PR TITLE
Adding verbose and changing threads for test-analyze-commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,12 @@ set(PYTEST_NUMPROCS
     CACHE STRING "Number of parallel threads to use with CPU-oriented tests")
 message(STATUS "Pytest CPU threadcount: ${PYTEST_NUMPROCS}")
 
+#2 CPU threads available for testing(test-analyze-commands)
+set(PYTEST_NUMPROCS_ANALYSIS
+    "4"
+    CACHE STRING "Number of parallel threads to use with CPU-oriented tests")
+message(STATUS "Pytest CPU threadcount: ${PYTEST_NUMPROCS_ANALYSIS}")
+
 # ---------------------------
 # profile mode tests
 # ---------------------------
@@ -269,8 +275,8 @@ set_tests_properties(
 add_test(
     NAME test_analyze_commands
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS}
-        --junitxml=tests/test_analyze_commands.xml ${COV_OPTION}
+        ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS_ANALYSIS}
+          --verbose --junitxml=tests/test_analyze_commands.xml ${COV_OPTION}
         ${PROJECT_SOURCE_DIR}/tests/test_analyze_commands.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [x] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
This will decrease testing time of analysis mode and produce output for long running analysis testing

## Have you added or updated tests to validate functionality?

- [x] Yes
- [ ] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
