### PR TITLE
Add roofline PDF output to general profiling runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
   * VGPR Writes
   * Total FLOPs (consider fp6 and fp4 ops)
 * Update Dash to >=3.0.0 (for web UI)
+* Change when Roofline PDFs are generated- during general profiling and --roof-only profiling (skip only when --no-roof option is present)
 
 ### Resolved issues
 

--- a/docs/how-to/profile/mode.rst
+++ b/docs/how-to/profile/mode.rst
@@ -196,7 +196,9 @@ an Instinct MI210 vs an Instinct MI250.
    Additionally, you will notice a few extra files. An SoC parameters file,
    ``sysinfo.csv``, is created to reflect the target device settings. All
    profiling output is stored in ``log.txt``. Roofline-specific benchmark
-   results are stored in ``roofline.csv``.
+   results are stored in ``roofline.csv`` and roofline plots are outputted into PDFs as
+   ``empirRoof_gpu-0_[datatype1]_..._[datatypeN].pdf`` where datatypes requested through
+    --roofline-data-type option are listed in the file name.
 
 .. code-block:: shell-session
 

--- a/src/roofline.py
+++ b/src/roofline.py
@@ -89,7 +89,7 @@ class Roofline:
         # Set roofline run parameters from args
         if hasattr(self.__args, "path") and not run_parameters:
             self.__run_parameters["workload_dir"] = self.__args.path
-        if not hasattr(self.__args, "no_roof") and not self.__args.no_roof == True:
+        if hasattr(self.__args, "no_roof") and self.__args.no_roof == False:
             self.__run_parameters["is_standalone"] = True
         if hasattr(self.__args, "kernel_names") and self.__args.kernel_names:
             self.__run_parameters["include_kernel_names"] = True

--- a/src/roofline.py
+++ b/src/roofline.py
@@ -89,7 +89,7 @@ class Roofline:
         # Set roofline run parameters from args
         if hasattr(self.__args, "path") and not run_parameters:
             self.__run_parameters["workload_dir"] = self.__args.path
-        if hasattr(self.__args, "roof_only") and self.__args.roof_only:
+        if not hasattr(self.__args, "no_roof") and not self.__args.no_roof == True:
             self.__run_parameters["is_standalone"] = True
         if hasattr(self.__args, "kernel_names") and self.__args.kernel_names:
             self.__run_parameters["include_kernel_names"] = True
@@ -104,7 +104,7 @@ class Roofline:
         if self.__run_parameters["include_kernel_names"] and (
             not self.__run_parameters["is_standalone"]
         ):
-            console_error("--roof-only is required for --kernel-names")
+            console_error("--kernel-names cannot be used with --no-roof option")
 
     def roof_setup(self):
         # Setup the workload directory for roofline profiling.


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [X] Closes #<issue number or link> SWDEV-489714

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [X] Other (please specify)
User request for functionality, ease of use, workflow

## Technical Details
<!-- Please explain the changes. -->
Adding roofline PDF outputs to general profiling, instead of solely when using --roof-only option.
We are already doing roofline profiling, which is main time-consuming activity, adding pdf outputs is minimal to this time. Users confused when running --roof-only and then general profiling deleing the roofline PDFs, unhappy with the selective ordering required to see the PDF plots. Adding PDF outputs to both profiling options simplifies workflow for users without large time impact.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [X] No - does not apply to this PR
Verified possible roofline options and run orders manually. Ran ctest suite on MI300X system to verify passing- adding roofline pdf output to general profiling calls do not affect directory file checks done by certain tests.

## Added / Updated documentation?

- [X] Yes
- [ ] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [X] Yes
- [ ] No - does not apply to this PR
