### PR TITLE
Fix SPI block counter limit

### DIFF
--- a/src/utils/mi_gpu_spec.yaml
+++ b/src/utils/mi_gpu_spec.yaml
@@ -9,7 +9,7 @@
 # MI GPUs
 #   |-- series: the specific MI series; mi50, mi100, mi200, mi300
 #       |-- architecture: currently, only mi300 gpus hold different architectures
-#           |-- perfmon_config
+#           |-- perfmon_config, copy from ROCm/aqlprofile from gfxip/gfx9/gfx9_block_info.h
 #           |-- gpu model
 #           |-- chip_ids: chip id is specific to the environment the gpu is being used on
 #               | -- physical
@@ -32,7 +32,7 @@ mi_gpu_spec:
           TCC: 4
           CPC: 2
           CPF: 2
-          SPI: 2
+          SPI: 6
           GRBM: 2
           GDS: 4
         models:
@@ -50,7 +50,7 @@ mi_gpu_spec:
           TCC: 4
           CPC: 2
           CPF: 2
-          SPI: 2
+          SPI: 6
           GRBM: 2
           GDS: 4
         models:
@@ -69,7 +69,7 @@ mi_gpu_spec:
           TCC: 4
           CPC: 2
           CPF: 2
-          SPI: 2
+          SPI: 6
           GRBM: 2
           GDS: 4
         models:
@@ -94,7 +94,7 @@ mi_gpu_spec:
           TCC: 4
           CPC: 2
           CPF: 2
-          SPI: 2
+          SPI: 6
           GRBM: 2
           GDS: 4
         models:
@@ -124,7 +124,7 @@ mi_gpu_spec:
           TCC: 4
           CPC: 2
           CPF: 2
-          SPI: 2
+          SPI: 6
           GRBM: 2
           GDS: 4
         models:
@@ -159,7 +159,7 @@ mi_gpu_spec:
           TCC: 4
           CPC: 2
           CPF: 2
-          SPI: 2
+          SPI: 6
           GRBM: 2
           GDS: 4
         models:
@@ -294,7 +294,7 @@ mi_gpu_spec:
           TCC: 4
           CPC: 2
           CPF: 2
-          SPI: 2
+          SPI: 6
           GRBM: 2
           GDS: 4
           TCC_channels: 16

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -157,21 +157,6 @@ def extract_counter_info_extra_config_input_yaml(
     return None
 
 
-def is_spi_pipe_counter(counter):
-    for pattern in spi_pipe_counter_regexs:
-        if re.match(pattern, counter):
-            return True
-    return False
-
-
-def get_base_spi_pipe_counter(counter):
-    for pattern in spi_pipe_counter_regexs:
-        match = re.match(pattern, counter)
-        if match:
-            return match.group(1)
-    return ""
-
-
 def using_v1():
     return "ROCPROF" in os.environ.keys() and os.environ["ROCPROF"].endswith("rocprof")
 


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
* Update SPI block counter collection limit per https://github.com/ROCm/aqlprofile/blob/8885887302e3cf78ccef0fdd05307d913ec18979/gfxip/gfx9/gfx9_block_info.h#L143C24-L143C54

* Remove special handling of SPI pipe counters for MI 350

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [ ] No - does not apply to this PR

* Confirmed working profiling on MI 350

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
