### PR TITLE
FP8 support documentation update to ROCm 642

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * 8-bit floating point (FP8) metrics support for AMD Instinct MI300 GPUs.
 * Additional data types for roofline: FP8, FP16, BF16, FP32, FP64, I8, I32, I64 (dependent on the GPU architecture).
 * Data type selection option ``--roofline-data-type / -R`` for roofline profiling. The default data type is FP32.
-* Change dependency from rocm-smi to amd-smi
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,12 @@ set(PYTEST_NUMPROCS
     CACHE STRING "Number of parallel threads to use with CPU-oriented tests")
 message(STATUS "Pytest CPU threadcount: ${PYTEST_NUMPROCS}")
 
+# 2 CPU threads available for testing(test-analyze-commands)
+set(PYTEST_NUMPROCS_ANALYSIS
+    "4"
+    CACHE STRING "Number of parallel threads to use with CPU-oriented tests")
+message(STATUS "Pytest CPU threadcount: ${PYTEST_NUMPROCS_ANALYSIS}")
+
 # ---------------------------
 # profile mode tests
 # ---------------------------
@@ -261,7 +267,7 @@ set_tests_properties(
 add_test(
     NAME test_analyze_commands
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS}
+        ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS_ANALYSIS} --verbose
         --junitxml=tests/test_analyze_commands.xml ${COV_OPTION}
         ${PROJECT_SOURCE_DIR}/tests/test_analyze_commands.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/docs/conceptual/pipeline-metrics.rst
+++ b/docs/conceptual/pipeline-metrics.rst
@@ -519,6 +519,13 @@ MFMA instructions are classified by the type of input data they operate on, and
 
      - Instructions per :ref:`normalization unit <normalization-units>`
 
+   * - MFMA-F8 Instructions
+
+     - The total number of 8-bit floating point :ref:`MFMA <desc-mfma>`
+       instructions issued per :ref:`normalization unit <normalization-units>`. This is supported in AMD Instinct MI300 series and later only.
+
+     - Instructions per :ref:`normalization unit <normalization-units>`
+
    * - MFMA-F16 Instructions
 
      - The total number of 16-bit floating point :ref:`MFMA <desc-mfma>`

--- a/docs/conceptual/system-speed-of-light.rst
+++ b/docs/conceptual/system-speed-of-light.rst
@@ -49,6 +49,16 @@ of ROCm Compute Profiler’s profiling report.
 
      - GIOPs
 
+   * - :ref:`MFMA <desc-mfma>` FLOPs (F8)
+
+     - The total number of 8-bit floating point :ref:`MFMA <desc-mfma>`
+       operations executed per second. This does not include any 16-bit
+       brain floating point operations from :ref:`VALU <desc-valu>`
+       instructions. This is also presented as a percent of the peak theoretical
+       F8 MFMA operations achievable on the specific accelerator. It is supported on AMD Instinct MI300 series and later only.
+
+     - GFLOPs
+
    * - :ref:`MFMA <desc-mfma>` FLOPs (BF16)
 
      - The total number of 16-bit brain floating point :ref:`MFMA <desc-mfma>`


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [X] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
Cherry-picked https://github.com/ROCm/rocprofiler-compute/pull/766 to the release/6.4.2 branch to include documentation reference for FP8 support.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [x] Yes
- [ ] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
