### PR TITLE
Fix method return for python version compatibility

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -39,6 +39,7 @@ import time
 from collections import OrderedDict
 from itertools import product
 from pathlib import Path as path
+from typing import Optional
 
 import pandas as pd
 import yaml
@@ -139,7 +140,7 @@ def add_counter_extra_config_input_yaml(
 
 def extract_counter_info_extra_config_input_yaml(
     data: dict, counter_name: str
-) -> dict | None:
+) -> Optional[dict]:
     """
     Extract the full counter dictionary from 'data' for the given counter_name.
 
@@ -148,7 +149,7 @@ def extract_counter_info_extra_config_input_yaml(
         counter_name (str): The counter to find.
 
     Returns:
-        dict | None: The full counter dict if found, else None.
+        Optional[dict]: The full counter dict if found, else None.
     """
     counters = data.get("rocprofiler-sdk", {}).get("counters", [])
     for counter in counters:


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [X] Closes #<issue number or link> internal

## What type of PR is this? (check all that apply)

- [X] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
Support for python3.8 and above means union defined in one of the methods was throwing errors for anything less than python3.10. Swapping out | operand for Optional[] resolves errors on systems using <3.10. No functional changes.

Tested on MI350 series system using rhel8 image with latest builds installed, with python 3.8 to verify issue is reproducible, and code changes resolves errors.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [X] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [X] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [X] No - does not apply to this PR
