### PR TITLE
[fix][gui] Fix normalization

### DIFF
--- a/src/rocprof_compute_analyze/analysis_webui.py
+++ b/src/rocprof_compute_analyze/analysis_webui.py
@@ -107,7 +107,9 @@ class webui_analysis(OmniAnalyze_Base):
         ):
             console_debug("analysis", "gui normalization is %s" % norm_filt)
 
-            base_data = self.initalize_runs()  # Re-initalizes everything
+            # Re-initalizes everything
+            base_data = self.initalize_runs(normalization_filter=norm_filt)
+
             panel_configs = copy.deepcopy(arch_configs.panel_configs)
             # Generate original raw df
             base_data[base_run].raw_pmc = file_io.create_df_pmc(


### PR DESCRIPTION
Fixes https://github.com/ROCm/rocprofiler-compute/issues/788 from what I tried:

![image](https://github.com/user-attachments/assets/394e22a0-0ab0-481e-a9fb-4d4931a1d1ad)

@coleramos425 do you know why this bug occurs? I recall a few months back (maybe end 2024) I tried rocperf-compute, and back then the gui normalization was working. However I looked at a few commits from that time and we already had `base_data = self.initalize_runs()` without `norm_filt` being passed.

Was something changed in the logic somewhere else? Do you think this fix is correct?