### PR TITLE
PC Sampling: fix potential_end_offset

### DIFF
--- a/src/rocprof_compute_soc/soc_base.py
+++ b/src/rocprof_compute_soc/soc_base.py
@@ -513,6 +513,7 @@ class OmniSoC_Base:
                 )
             )
             from rocprofv3_avail_module import avail
+
             avail.loadLibrary.libname = str(
                 Path(self.get_args().rocprofiler_sdk_library_path).parent.parent
                 / "libexec"

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -1196,7 +1196,7 @@ def load_pc_sampling_data_per_kernel(
             next_index = i + 1
             if next_index < len(filtered_sorted_list):  # Ensure the next item exists
                 next_item = filtered_sorted_list[next_index]
-                kernel_info["potential_end_offset"] = item[
+                kernel_info["potential_end_offset"] = next_item[
                     "kernel_code_entry_byte_offset"
                 ]
             else:


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [X] Closes SWDEV-541194

## What type of PR is this? (check all that apply)

- [X] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
For multiple kernels pc sampling, there is a bug in the logic to detect the potential end code obj offset of a given kernel. 
This quick fix should only impact pc sampling with multiple kernels.

Tested single kernel case locally.
Tested single kernel in multiple kernel case locally. 

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [X] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [X] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [X] No - does not apply to this PR
