### PR TITLE
Improve baseline comparison logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
   * OS distribution support minimum for roofline feature is now Ubuntu22.04, RHEL9, and SLES15SP6
 * Improve analysis block based filtering to accept metric id level filtering
   * This can be used to collect individual metrics from various sections of analysis config
+* CLI analysis mode baseline comparison will now only compare common metrics across workloads and will not show Metric ID
+  * Remove metrics from analysis configuration files which are explicitly marked as empty or None
 
 ### Optimized
 

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/0200_system-speed-of-light.yaml
@@ -32,12 +32,6 @@ Panel Config:
             peak: (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000)
             pop: None # No perf counter
             tips:
-          MFMA FLOPs (F8):
-            value: None # No HW module
-            unit: GFLOP/s
-            peak: None # No HW module
-            pop: None # No HW module
-            tips:
           MFMA FLOPs (BF16):
             value: None # No perf counter
             unit: GFLOP/s
@@ -61,13 +55,6 @@ Panel Config:
             unit: GFLOP/s
             peak: ((($max_sclk * $cu_per_gpu) * 256) / 1000)
             pop: None # No perf counter
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP/s
-            peak: None
-            pop: None
             tips:
           MFMA IOPs (Int8):
             value: None # No perf counter

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/0300_mem_chart.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/0300_mem_chart.yaml
@@ -45,10 +45,6 @@ Panel Config:
             #alias: valu_
             value: ROUND(AVG((SQ_INSTS_VALU / $denom)), 0)
             tips:
-          MFMA:
-            #alias: mfma_
-            value: None # No perf counter
-            tips:
           VMEM:
             #alias: vmem_
             value: ROUND(AVG((SQ_INSTS_VMEM / $denom)), 0)

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/0500_command-processor.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/0500_command-processor.yaml
@@ -19,27 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC SYNC FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC CANE Stall Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC ADC Utilization:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
           CPF Utilization:
             avg: AVG((((100 * CPF_CPF_STAT_BUSY) / (CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE))
               if ((CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE) != 0) else None))

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/0600_shader-processor-input.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/0600_shader-processor-input.yaml
@@ -19,13 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Schedule-Pipe Wave Occupancy:
-            avg: None
-            min: None
-            max: None
-            unit: Wave
-            tips:
           Accelerator Utilization:
             avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
@@ -36,13 +29,6 @@ Panel Config:
             avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe Wave Utilization:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Workgroup Manager Utilization:
@@ -120,13 +106,6 @@ Panel Config:
               0) else None)
             max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $se_per_gpu)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Scheduler-Pipe Stall Rate:

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/1000_compute-unit-instruction-mix.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/1000_compute-unit-instruction-mix.yaml
@@ -19,28 +19,10 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          VALU:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: (instr + $normUnit)
-            tips:
-          VMEM:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: (instr + $normUnit)
-            tips:
           LDS:
             avg: AVG((SQ_INSTS_LDS / $denom))
             min: MIN((SQ_INSTS_LDS / $denom))
             max: MAX((SQ_INSTS_LDS / $denom))
-            unit: (instr + $normUnit)
-            tips:
-          MFMA:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
             unit: (instr + $normUnit)
             tips:
           SALU:
@@ -73,96 +55,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          INT32:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          INT64:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F16-ADD:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F16-MUL:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F16-FMA:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F16-Trans:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F32-ADD:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F32-MUL:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F32-FMA:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F32-Trans:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F64-ADD:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F64-MUL:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F64-FMA:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          F64-Trans:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
-          Conversion:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (instr + $normUnit)
-            tips:
 
     - metric_table:
         id: 1003
@@ -179,13 +71,6 @@ Panel Config:
             avg: AVG((TA_FLAT_WAVEFRONTS_sum / $denom))
             min: MIN((TA_FLAT_WAVEFRONTS_sum / $denom))
             max: MAX((TA_FLAT_WAVEFRONTS_sum / $denom))
-            unit: (instr + $normUnit)
-            tips:
-         # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          Spill/Stack Coalesceable Instr:
-            avg: None
-            min: None
-            max: None
             unit: (instr + $normUnit)
             tips:
           Global/Generic Read:
@@ -242,46 +127,3 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          MFMA-I8:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: (instr + $normUnit)
-            tips:
-          MFMA-F8:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module None # No HW module
-            unit: (instr + $normUnit)
-            tips:
-          MFMA-F16:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: (instr + $normUnit)
-            tips:
-          MFMA-BF16:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: (instr + $normUnit)
-            tips:
-          MFMA-F32:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: (instr + $normUnit)
-            tips:
-          MFMA-F64:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA-F6F4:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/1100_compute-unit-compute-pipeline.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/1100_compute-unit-compute-pipeline.yaml
@@ -19,61 +19,6 @@ Panel Config:
           pop: Pct of Peak
           tips: Tips
         metric:
-          VALU FLOPs:
-            value: None # No perf counter
-            unit: None
-            peak: None
-            pop: None
-            tips:
-          VALU IOPs:
-            value: None # No perf counter
-            unit: None
-            peak: None
-            pop: None
-            tips:
-          MFMA FLOPs (F8):
-            value: None # No perf counter
-            unit: GFLOP
-            peak: None # No perf counter
-            pop: None # No perf counter
-            tips:
-          MFMA FLOPs (BF16):
-            value: None # No perf counter
-            Unit: None
-            peak: None
-            pop: None
-            tips:
-          MFMA FLOPs (F16):
-            value: None # No perf counter
-            unit: None
-            peak: None
-            pop: None
-            tips:
-          MFMA FLOPs (F32):
-            value: None # No perf counter
-            unit: None
-            peak: None
-            pop: None
-            tips:
-          MFMA FLOPs (F64):
-            value: None # No perf counter
-            unit: None
-            peak: None
-            pop: None
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP
-            peak: None
-            pop: None
-            tips:
-          MFMA IOPs (INT8):
-            value: None # No perf counter
-            unit: None
-            peak: None
-            pop: None
-            tips:
 
     - metric_table:
         id: 1102
@@ -116,25 +61,6 @@ Panel Config:
             max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             unit: pct
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          VALU Co-Issue Efficiency:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          VMEM Utilization:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: pct
-            tips:
-          Branch Utilization:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: pct
-            tips:
           VALU Active Threads:
             avg: AVG(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
               != 0) else None))
@@ -143,32 +69,6 @@ Panel Config:
             max: MAX(((SQ_THREAD_CYCLES_VALU / SQ_ACTIVE_INST_VALU) if (SQ_ACTIVE_INST_VALU
               != 0) else None))
             unit: Threads
-            tips:
-          MFMA Utilization:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: pct
-            tips:
-          MFMA Instr Cycles:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: cycles/instr
-            tips:
-          VMEM Latency:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: Cycles
-            coll_level: SQ_INST_LEVEL_VMEM
-            tips:
-          SMEM Latency:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: Cycles
-            coll_level: SQ_INST_LEVEL_SMEM
             tips:
 
     - metric_table:
@@ -182,58 +82,3 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          FLOPs (Total):
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (OPs  + $normUnit)
-            tips:
-          IOPs (Total):
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (OPs  + $normUnit)
-            tips:
-          F8 OPs:
-            avg: None # No HW module
-            min: None # No HW module
-            max: None # No HW module
-            unit: (OPs  + $normUnit)
-            tips:
-          F16 OPs:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (OPs  + $normUnit)
-            tips:
-          BF16 OPs:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (OPs  + $normUnit)
-            tips:
-          F32 OPs:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (OPs  + $normUnit)
-            tips:
-          F64 OPs:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (OPs  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          F6F4 OPs:
-            avg: None
-            min: None
-            max: None
-            unit: (OPs  + $normUnit)
-            tips:
-          INT8 OPs:
-            avg: None # No perf counter
-            min: None # No perf counter
-            max: None # No perf counter
-            unit: (OPs  + $normUnit)
-            tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/1200_lds.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/1200_lds.yaml
@@ -55,48 +55,6 @@ Panel Config:
             max: MAX((SQ_INSTS_LDS / $denom))
             unit: (Instr  + $normUnit)
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS LOAD:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS STORE:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS ATOMIC:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS LOAD Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS STORE Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS ATOMIC Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
           Theoretical Bandwidth:
             avg: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
               / $denom))
@@ -157,18 +115,4 @@ Panel Config:
             min: MIN((SQ_LDS_MEM_VIOLATIONS / $denom))
             max: MAX((SQ_LDS_MEM_VIOLATIONS / $denom))
             unit: (Accesses + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS Command FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS Data FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/1500_TA_and_TD.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/1500_TA_and_TD.yaml
@@ -43,27 +43,6 @@ Panel Config:
             max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
             unit: pct
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Address Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Command Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Data Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
           Total Instructions:
             avg: AVG((TA_TOTAL_WAVEFRONTS_sum / $denom))
             min: MIN((TA_TOTAL_WAVEFRONTS_sum / $denom))
@@ -80,12 +59,6 @@ Panel Config:
             avg: AVG((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Global/Generic Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Global/Generic Write Instructions:
@@ -110,12 +83,6 @@ Panel Config:
             avg: AVG((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Spill/Stack Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Spill/Stack Write Instructions:
@@ -172,12 +139,6 @@ Panel Config:
             max: MAX(((100 * TD_TC_STALL_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
             unit: pct
             tips:
-          Workgroup manager → Data-Return Stall:
-            avg: # No perf counter
-            min: # No perf counter
-            max: # No perf counter
-            unit: pct
-            tips:
           Coalescable Instructions:
             avg: AVG((TD_COALESCABLE_WAVEFRONT_sum / $denom))
             min: MIN((TD_COALESCABLE_WAVEFRONT_sum / $denom))
@@ -203,11 +164,5 @@ Panel Config:
             avg: AVG((TD_ATOMIC_WAVEFRONT_sum / $denom))
             min: MIN((TD_ATOMIC_WAVEFRONT_sum / $denom))
             max: MAX((TD_ATOMIC_WAVEFRONT_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Write Ack Instructions:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/1600_L1_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/1600_L1_cache.yaml
@@ -189,30 +189,6 @@ Panel Config:
               + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
-          Tag RAM 0 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 1 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 2 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 3 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           L1-L2 Read:
             avg: AVG((TCP_TCC_READ_REQ_sum / $denom))
             min: MIN((TCP_TCC_READ_REQ_sum / $denom))
@@ -419,12 +395,6 @@ Panel Config:
             max: MAX((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             units: (Req + $normUnit)
             tips:
-          Misses under Translation Miss:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Req + $normUnit)
-            tips:
           Permission Misses:
             avg: AVG((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
@@ -442,45 +412,3 @@ Panel Config:
           units: Units
           tips: Tips
         metric:
-          Cache Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Cache Miss Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Serialization Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Thrashing Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Latency FIFO Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Resident Page Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          UTCL2 Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/1700_L2_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/1700_L2_cache.yaml
@@ -143,18 +143,6 @@ Panel Config:
               != 0) else None))
             unit: Cycles
             tips:
-          Read Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
 
     - metric_table:
         id: 1703
@@ -171,24 +159,6 @@ Panel Config:
             avg: AVG((TCC_REQ_sum * 64) / $denom)
             min: MIN((TCC_REQ_sum * 64) / $denom)
             max: MAX((TCC_REQ_sum * 64) / $denom)
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Bytes + $normUnit)
             tips:
           Req:
@@ -221,22 +191,10 @@ Panel Config:
             max: MAX((TCC_STREAMING_REQ_sum / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Bypasss Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           Probe Req:
             avg: AVG((TCC_PROBE_sum / $denom))
             min: MIN((TCC_PROBE_sum / $denom))
             max: MAX((TCC_PROBE_sum / $denom))
-            unit: (Req  + $normUnit)
-            tips:
-          Input Buffer Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Req  + $normUnit)
             tips:
           Cache Hit:
@@ -326,24 +284,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          Stalled on Latency FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Stalled on Write Data FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Input Buffer Stalled on L2:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
 
     - metric_table:
         id: 1705
@@ -360,54 +300,6 @@ Panel Config:
         style:
           type: simple_multi_bar
         metric:
-          Read - PCIe Stall:
-            type: PCIe Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - HBM Stall:
-            type: HBM Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - PCIe Stall:
-            type: PCIe Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - HBM Stall:
-            type: HBM Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
           Write - Credit Starvation:
             type: Credit Starvation
             transaction: Write
@@ -458,24 +350,6 @@ Panel Config:
             max: MAX((MAX((TCC_EA_RDREQ_sum - TCC_EA_RDREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Read Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Write and Atomic (32B):
             avg: AVG(((TCC_EA_WRREQ_sum - TCC_EA_WRREQ_64B_sum) / $denom))
             min: MIN(((TCC_EA_WRREQ_sum - TCC_EA_WRREQ_64B_sum) / $denom))
@@ -506,51 +380,9 @@ Panel Config:
             max: MAX((MAX((TCC_EA_WRREQ_sum - TCC_EA_WRREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Write Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Atomic:
             avg: AVG((TCC_EA_ATOMIC_sum / $denom))
             min: MIN((TCC_EA_ATOMIC_sum / $denom))
             max: MAX((TCC_EA_ATOMIC_sum / $denom))
             unit: (Req  + $normUnit)
-            tips:
-          Atomic - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Atomic Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx908/1800_L2_cache_per_channel.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx908/1800_L2_cache_per_channel.yaml
@@ -333,3 +333,18 @@ Panel Config:
           placeholder_range:
             "::_1": $total_l2_chan
         cli_style: simple_multiple_bar
+
+    - metric_table:
+        id: 1812
+        title: L2-Fabric (128B read requests per normUnit)
+        header:
+          metric: Channel
+          expr: Expression
+        metric:
+          "::_1":
+            expr: (TO_INT(TCC_BUBBLE[::_1]) / $denom)
+          placeholder_range:
+            "::_1": $total_l2_chan
+          # tips: Number of 128-byte read requests sent to EA
+        cli_style: simple_box
+        tui_style: simple_box

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/0200_system-speed-of-light.yaml
@@ -42,12 +42,6 @@ Panel Config:
             pop: ((100 * AVG(((64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / (End_Timestamp
               - Start_Timestamp)))) / (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000))
             tips:
-          MFMA FLOPs (F8):
-            value: None
-            unit: GFLOP/s
-            peak: None
-            pop: None
-            tips:
           MFMA FLOPs (BF16):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (End_Timestamp - Start_Timestamp)))
             unit: GFLOP/s
@@ -75,13 +69,6 @@ Panel Config:
             peak: ((($max_sclk * $cu_per_gpu) * 256) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp))))
               / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP/s
-            peak: None
-            pop: None
             tips:
           MFMA IOPs (Int8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/0500_command-processor.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/0500_command-processor.yaml
@@ -19,24 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          CPC SYNC FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          CPC CANE Stall Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          CPC ADC Utilization:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
           CPF Utilization:
             avg: AVG((((100 * CPF_CPF_STAT_BUSY) / (CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE))
               if ((CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE) != 0) else None))

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/0600_shader-processor-input.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/0600_shader-processor-input.yaml
@@ -19,13 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Schedule-Pipe Wave Occupancy:
-            avg: None
-            min: None
-            max: None
-            unit: Wave
-            tips:
           Accelerator Utilization:
             avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
@@ -36,13 +29,6 @@ Panel Config:
             avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe Wave Utilization:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Workgroup Manager Utilization:
@@ -120,13 +106,6 @@ Panel Config:
               0) else None)
             max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $se_per_gpu)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Scheduler-Pipe Stall Rate:

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/1000_compute-unit-instruction-mix.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/1000_compute-unit-instruction-mix.yaml
@@ -181,13 +181,6 @@ Panel Config:
             max: MAX((TA_FLAT_WAVEFRONTS_sum / $denom))
             unit: (instr + $normUnit)
             tips:
-         # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          Spill/Stack Coalesceable Instr:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
           Global/Generic Read:
             avg: AVG((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
@@ -248,12 +241,6 @@ Panel Config:
             max: MAX((SQ_INSTS_VALU_MFMA_I8 / $denom))
             unit: (instr + $normUnit)
             tips:
-          MFMA-F8:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
           MFMA-F16:
             avg: AVG((SQ_INSTS_VALU_MFMA_F16 / $denom))
             min: MIN((SQ_INSTS_VALU_MFMA_F16 / $denom))
@@ -276,12 +263,5 @@ Panel Config:
             avg: AVG((SQ_INSTS_VALU_MFMA_F64 / $denom))
             min: MIN((SQ_INSTS_VALU_MFMA_F64 / $denom))
             max: MAX((SQ_INSTS_VALU_MFMA_F64 / $denom))
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA-F6F4:
-            avg: None
-            min: None
-            max: None
             unit: (instr + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/1100_compute-unit-compute-pipeline.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/1100_compute-unit-compute-pipeline.yaml
@@ -41,12 +41,6 @@ Panel Config:
             pop: ((100 * AVG(((64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / (End_Timestamp
               - Start_Timestamp)))) / (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000))
             tips:
-          MFMA FLOPs (F8):
-            value: None
-            unit: GFLOP
-            peak: None
-            pop: None
-            tips:
           MFMA FLOPs (BF16):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (End_Timestamp - Start_Timestamp)))
             unit: GFLOP
@@ -74,13 +68,6 @@ Panel Config:
             peak: ((($max_sclk * $cu_per_gpu) * 256) / 1000)
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp))))
               / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP
-            peak: None
-            pop: None
             tips:
           MFMA IOPs (INT8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
@@ -129,13 +116,6 @@ Panel Config:
             avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          VALU Co-Issue Efficiency:
-            avg: None
-            min: None
-            max: None
             unit: pct
             tips:
           VMEM Utilization:
@@ -236,12 +216,6 @@ Panel Config:
             max: MAX(((64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) + (SQ_INSTS_VALU_MFMA_MOPS_I8 * 512)) / $denom)
             unit: (OPs  + $normUnit)
             tips:
-          F8 OPs:
-            avg: None
-            min: None
-            max: None
-            unit: (OPs  + $normUnit)
-            tips:
           F16 OPs:
             avg: AVG(((((((64 * SQ_INSTS_VALU_ADD_F16) + (64 * SQ_INSTS_VALU_MUL_F16)) +
               (64 * SQ_INSTS_VALU_TRANS_F16)) + (128 * SQ_INSTS_VALU_FMA_F16)) + (512 *
@@ -276,13 +250,6 @@ Panel Config:
               + (SQ_INSTS_VALU_FMA_F64 * 2))) + (512 * SQ_INSTS_VALU_MFMA_MOPS_F64)) / $denom))
             max: MAX((((64 * (((SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64) + SQ_INSTS_VALU_TRANS_F64)
               + (SQ_INSTS_VALU_FMA_F64 * 2))) + (512 * SQ_INSTS_VALU_MFMA_MOPS_F64)) / $denom))
-            unit: (OPs  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          F6F4 OPs:
-            avg: None
-            min: None
-            max: None
             unit: (OPs  + $normUnit)
             tips:
           INT8 OPs:

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/1200_lds.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/1200_lds.yaml
@@ -55,48 +55,6 @@ Panel Config:
             max: MAX((SQ_INSTS_LDS / $denom))
             unit: (Instr  + $normUnit)
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS LOAD:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS STORE:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS ATOMIC:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS LOAD Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS STORE Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS ATOMIC Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
           Theoretical Bandwidth:
             avg: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
               / $denom))
@@ -157,18 +115,4 @@ Panel Config:
             min: MIN((SQ_LDS_MEM_VIOLATIONS / $denom))
             max: MAX((SQ_LDS_MEM_VIOLATIONS / $denom))
             unit: (Accesses + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS Command FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS Data FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/1500_TA_and_TD.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/1500_TA_and_TD.yaml
@@ -43,27 +43,6 @@ Panel Config:
             max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
             unit: pct
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Address Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Command Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Data Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
           Total Instructions:
             avg: AVG((TA_TOTAL_WAVEFRONTS_sum / $denom))
             min: MIN((TA_TOTAL_WAVEFRONTS_sum / $denom))
@@ -80,12 +59,6 @@ Panel Config:
             avg: AVG((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Global/Generic Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Global/Generic Write Instructions:
@@ -110,12 +83,6 @@ Panel Config:
             avg: AVG((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Spill/Stack Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Spill/Stack Write Instructions:
@@ -203,11 +170,5 @@ Panel Config:
             avg: AVG((TD_ATOMIC_WAVEFRONT_sum / $denom))
             min: MIN((TD_ATOMIC_WAVEFRONT_sum / $denom))
             max: MAX((TD_ATOMIC_WAVEFRONT_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Write Ack Instructions:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/1600_L1_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/1600_L1_cache.yaml
@@ -189,30 +189,6 @@ Panel Config:
               + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
-          Tag RAM 0 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 1 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 2 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 3 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           L1-L2 Read:
             avg: AVG((TCP_TCC_READ_REQ_sum / $denom))
             min: MIN((TCP_TCC_READ_REQ_sum / $denom))
@@ -419,12 +395,6 @@ Panel Config:
             max: MAX((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             units: (Req + $normUnit)
             tips:
-          Misses under Translation Miss:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Req + $normUnit)
-            tips:
           Permission Misses:
             avg: AVG((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
@@ -442,45 +412,3 @@ Panel Config:
           units: Units
           tips: Tips
         metric:
-          Cache Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Cache Miss Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Serialization Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Thrashing Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Latency FIFO Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Resident Page Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          UTCL2 Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/1700_L2_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/1700_L2_cache.yaml
@@ -143,18 +143,6 @@ Panel Config:
               != 0) else None))
             unit: Cycles
             tips:
-          Read Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
 
     - metric_table:
         id: 1703
@@ -171,24 +159,6 @@ Panel Config:
             avg: AVG((TCC_REQ_sum * 128) / $denom)
             min: MIN((TCC_REQ_sum * 128) / $denom)
             max: MAX((TCC_REQ_sum * 128) / $denom)
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Bytes + $normUnit)
             tips:
           Req:
@@ -221,22 +191,10 @@ Panel Config:
             max: MAX((TCC_STREAMING_REQ_sum / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Bypasss Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           Probe Req:
             avg: AVG((TCC_PROBE_sum / $denom))
             min: MIN((TCC_PROBE_sum / $denom))
             max: MAX((TCC_PROBE_sum / $denom))
-            unit: (Req  + $normUnit)
-            tips:
-          Input Buffer Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Req  + $normUnit)
             tips:
           Cache Hit:
@@ -326,24 +284,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          Stalled on Latency FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Stalled on Write Data FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Input Buffer Stalled on L2:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
 
     - metric_table:
         id: 1705
@@ -360,54 +300,6 @@ Panel Config:
         style:
           type: simple_multi_bar
         metric:
-          Read - PCIe Stall:
-            type: PCIe Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - HBM Stall:
-            type: HBM Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - PCIe Stall:
-            type: PCIe Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - HBM Stall:
-            type: HBM Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
           Write - Credit Starvation:
             type: Credit Starvation
             transaction: Write
@@ -458,24 +350,6 @@ Panel Config:
             max: MAX((MAX((TCC_EA_RDREQ_sum - TCC_EA_RDREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Read Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Write and Atomic (32B):
             avg: AVG(((TCC_EA_WRREQ_sum - TCC_EA_WRREQ_64B_sum) / $denom))
             min: MIN(((TCC_EA_WRREQ_sum - TCC_EA_WRREQ_64B_sum) / $denom))
@@ -506,51 +380,9 @@ Panel Config:
             max: MAX((MAX((TCC_EA_WRREQ_sum - TCC_EA_WRREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Write Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Atomic:
             avg: AVG((TCC_EA_ATOMIC_sum / $denom))
             min: MIN((TCC_EA_ATOMIC_sum / $denom))
             max: MAX((TCC_EA_ATOMIC_sum / $denom))
             unit: (Req  + $normUnit)
-            tips:
-          Atomic - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Atomic Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx90a/1800_L2_cache_per_channel.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx90a/1800_L2_cache_per_channel.yaml
@@ -333,3 +333,18 @@ Panel Config:
           placeholder_range:
             "::_1": $total_l2_chan
         cli_style: simple_multiple_bar
+
+    - metric_table:
+        id: 1812
+        title: L2-Fabric (128B read requests per normUnit)
+        header:
+          metric: Channel
+          expr: Expression
+        metric:
+          "::_1":
+            expr: (TO_INT(TCC_BUBBLE[::_1]) / $denom)
+          placeholder_range:
+            "::_1": $total_l2_chan
+          # tips: Number of 128-byte read requests sent to EA
+        cli_style: simple_box
+        tui_style: simple_box

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/0200_system-speed-of-light.yaml
@@ -77,13 +77,6 @@ Panel Config:
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp))))
               / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP/s
-            peak: None
-            pop: None
-            tips:
           MFMA IOPs (Int8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
             unit: GIOP/s

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/0500_command-processor.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/0500_command-processor.yaml
@@ -19,27 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC SYNC FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC CANE Stall Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC ADC Utilization:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
           CPF Utilization:
             avg: AVG((((100 * CPF_CPF_STAT_BUSY) / (CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE))
               if ((CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE) != 0) else None))

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/0600_shader-processor-input.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/0600_shader-processor-input.yaml
@@ -19,13 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Schedule-Pipe Wave Occupancy:
-            avg: None
-            min: None
-            max: None
-            unit: Wave
-            tips:
           Accelerator Utilization:
             avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
@@ -36,13 +29,6 @@ Panel Config:
             avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe Wave Utilization:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Workgroup Manager Utilization:
@@ -120,13 +106,6 @@ Panel Config:
               0) else None)
             max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $se_per_gpu)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Scheduler-Pipe Stall Rate:

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/1000_compute-unit-instruction-mix.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/1000_compute-unit-instruction-mix.yaml
@@ -209,13 +209,6 @@ Panel Config:
             max: MAX((TA_BUFFER_WAVEFRONTS_sum / $denom))
             unit: (instr + $normUnit)
             tips:
-         # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          Spill/Stack Coalesceable Instr:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
           Spill/Stack Read:
             avg: AVG((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
@@ -280,10 +273,5 @@ Panel Config:
             avg: AVG((SQ_INSTS_VALU_MFMA_F64 / $denom))
             min: MIN((SQ_INSTS_VALU_MFMA_F64 / $denom))
             max: MAX((SQ_INSTS_VALU_MFMA_F64 / $denom))
-            unit: (instr + $normUnit)
-          MFMA-F6F4:
-            avg: None
-            min: None
-            max: None
             unit: (instr + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/1100_compute-unit-compute-pipeline.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/1100_compute-unit-compute-pipeline.yaml
@@ -76,13 +76,6 @@ Panel Config:
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp))))
               / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP
-            peak: None
-            pop: None
-            tips:
           MFMA IOPs (INT8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
             unit: GIOP
@@ -130,13 +123,6 @@ Panel Config:
             avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          VALU Co-Issue Efficiency:
-            avg: None
-            min: None
-            max: None
             unit: pct
             tips:
           VMEM Utilization:
@@ -277,13 +263,6 @@ Panel Config:
               + (SQ_INSTS_VALU_FMA_F64 * 2))) + (512 * SQ_INSTS_VALU_MFMA_MOPS_F64)) / $denom))
             max: MAX((((64 * (((SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64) + SQ_INSTS_VALU_TRANS_F64)
               + (SQ_INSTS_VALU_FMA_F64 * 2))) + (512 * SQ_INSTS_VALU_MFMA_MOPS_F64)) / $denom))
-            unit: (OPs  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          F6F4 OPs:
-            avg: None
-            min: None
-            max: None
             unit: (OPs  + $normUnit)
             tips:
           INT8 OPs:

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/1200_lds.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/1200_lds.yaml
@@ -55,48 +55,6 @@ Panel Config:
             max: MAX((SQ_INSTS_LDS / $denom))
             unit: (Instr  + $normUnit)
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS LOAD:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS STORE:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS ATOMIC:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS LOAD Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS STORE Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS ATOMIC Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
           Theoretical Bandwidth:
             avg: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
               / $denom))
@@ -157,18 +115,4 @@ Panel Config:
             min: MIN((SQ_LDS_MEM_VIOLATIONS / $denom))
             max: MAX((SQ_LDS_MEM_VIOLATIONS / $denom))
             unit: (Accesses + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS Command FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS Data FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/1500_TA_and_TD.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/1500_TA_and_TD.yaml
@@ -43,27 +43,6 @@ Panel Config:
             max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
             unit: pct
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Address Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Command Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Data Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
           Total Instructions:
             avg: AVG((TA_TOTAL_WAVEFRONTS_sum / $denom))
             min: MIN((TA_TOTAL_WAVEFRONTS_sum / $denom))
@@ -80,12 +59,6 @@ Panel Config:
             avg: AVG((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Global/Generic Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Global/Generic Write Instructions:
@@ -110,12 +83,6 @@ Panel Config:
             avg: AVG((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Spill/Stack Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Spill/Stack Write Instructions:
@@ -203,11 +170,5 @@ Panel Config:
             avg: AVG((TD_ATOMIC_WAVEFRONT_sum / $denom))
             min: MIN((TD_ATOMIC_WAVEFRONT_sum / $denom))
             max: MAX((TD_ATOMIC_WAVEFRONT_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Write Ack Instructions:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/1600_L1_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/1600_L1_cache.yaml
@@ -192,30 +192,6 @@ Panel Config:
                         TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
-          Tag RAM 0 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 1 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 2 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 3 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           L1-L2 Read:
             avg: AVG((TCP_TCC_READ_REQ_sum / $denom))
             min: MIN((TCP_TCC_READ_REQ_sum / $denom))
@@ -236,24 +212,6 @@ Panel Config:
             max: MAX(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
             unit: (Req  + $normUnit)
-            tips:
-          L1 Access Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
-            tips:
-          L1-L2 Read Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
-            tips:
-          L1-L2 Write Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
             tips:
 
     - metric_table:
@@ -410,12 +368,6 @@ Panel Config:
             max: MAX((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             units: (Req + $normUnit)
             tips:
-          Misses under Translation Miss:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Req + $normUnit)
-            tips:
           Permission Misses:
             avg: AVG((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
@@ -433,45 +385,3 @@ Panel Config:
           units: Units
           tips: Tips
         metric:
-          Cache Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Cache Miss Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Serialization Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Thrashing Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Latency FIFO Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Resident Page Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          UTCL2 Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx940/1700_L2_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx940/1700_L2_cache.yaml
@@ -146,18 +146,6 @@ Panel Config:
               != 0) else None))
             unit: Cycles
             tips:
-          Read Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
 
     - metric_table:
         id: 1703
@@ -174,24 +162,6 @@ Panel Config:
             avg: AVG((TCC_REQ_sum * 128) / $denom)
             min: MIN((TCC_REQ_sum * 128) / $denom)
             max: MAX((TCC_REQ_sum * 128) / $denom)
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Bytes + $normUnit)
             tips:
           Req:
@@ -224,22 +194,10 @@ Panel Config:
             max: MAX((TCC_STREAMING_REQ_sum / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Bypasss Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           Probe Req:
             avg: AVG((TCC_PROBE_sum / $denom))
             min: MIN((TCC_PROBE_sum / $denom))
             max: MAX((TCC_PROBE_sum / $denom))
-            unit: (Req  + $normUnit)
-            tips:
-          Input Buffer Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Req  + $normUnit)
             tips:
           Cache Hit:
@@ -329,24 +287,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          Stalled on Latency FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Stalled on Write Data FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Input Buffer Stalled on L2:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
 
     - metric_table:
         id: 1705
@@ -363,54 +303,6 @@ Panel Config:
         style:
           type: simple_multi_bar
         metric:
-          Read - PCIe Stall:
-            type: PCIe Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - HBM Stall:
-            type: HBM Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - PCIe Stall:
-            type: PCIe Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - HBM Stall:
-            type: HBM Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
           Write - Credit Starvation:
             type: Credit Starvation
             transaction: Write
@@ -461,24 +353,6 @@ Panel Config:
             max: MAX((MAX((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Read Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Write and Atomic (32B):
             avg: AVG(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             min: MIN(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
@@ -509,51 +383,9 @@ Panel Config:
             max: MAX((MAX((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Write Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Atomic:
             avg: AVG((TCC_EA0_ATOMIC_sum / $denom))
             min: MIN((TCC_EA0_ATOMIC_sum / $denom))
             max: MAX((TCC_EA0_ATOMIC_sum / $denom))
             unit: (Req  + $normUnit)
-            tips:
-          Atomic - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Atomic Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/0200_system-speed-of-light.yaml
@@ -77,13 +77,6 @@ Panel Config:
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp))))
               / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP/s
-            peak: None
-            pop: None
-            tips:
           MFMA IOPs (Int8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
             unit: GIOP/s

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/0500_command-processor.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/0500_command-processor.yaml
@@ -19,27 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          CPC SYNC FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          CPC CANE Stall Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          CPC ADC Utilization:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
           CPF Utilization:
             avg: AVG((((100 * CPF_CPF_STAT_BUSY) / (CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE))
               if ((CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE) != 0) else None))

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/0600_shader-processor-input.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/0600_shader-processor-input.yaml
@@ -19,13 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Schedule-Pipe Wave Occupancy:
-            avg: None
-            min: None
-            max: None
-            unit: Wave
-            tips:
           Accelerator Utilization:
             avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
@@ -36,13 +29,6 @@ Panel Config:
             avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe Wave Utilization:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Workgroup Manager Utilization:
@@ -120,13 +106,6 @@ Panel Config:
               0) else None)
             max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $se_per_gpu)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Scheduler-Pipe Stall Rate:

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/1000_compute-unit-instruction-mix.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/1000_compute-unit-instruction-mix.yaml
@@ -209,13 +209,6 @@ Panel Config:
             max: MAX((TA_BUFFER_WAVEFRONTS_sum / $denom))
             unit: (instr + $normUnit)
             tips:
-         # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          Spill/Stack Coalesceable Instr:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
           Spill/Stack Read:
             avg: AVG((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
@@ -280,12 +273,5 @@ Panel Config:
             avg: AVG((SQ_INSTS_VALU_MFMA_F64 / $denom))
             min: MIN((SQ_INSTS_VALU_MFMA_F64 / $denom))
             max: MAX((SQ_INSTS_VALU_MFMA_F64 / $denom))
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA-F6F4:
-            avg: None
-            min: None
-            max: None
             unit: (instr + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/1100_compute-unit-compute-pipeline.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/1100_compute-unit-compute-pipeline.yaml
@@ -76,13 +76,6 @@ Panel Config:
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp))))
               / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP
-            peak: None
-            pop: None
-            tips:
           MFMA IOPs (INT8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
             unit: GIOP
@@ -130,13 +123,6 @@ Panel Config:
             avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          VALU Co-Issue Efficiency:
-            avg: None
-            min: None
-            max: None
             unit: pct
             tips:
           VMEM Utilization:
@@ -277,13 +263,6 @@ Panel Config:
               + (SQ_INSTS_VALU_FMA_F64 * 2))) + (512 * SQ_INSTS_VALU_MFMA_MOPS_F64)) / $denom))
             max: MAX((((64 * (((SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64) + SQ_INSTS_VALU_TRANS_F64)
               + (SQ_INSTS_VALU_FMA_F64 * 2))) + (512 * SQ_INSTS_VALU_MFMA_MOPS_F64)) / $denom))
-            unit: (OPs  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          F6F4 OPs:
-            avg: None
-            min: None
-            max: None
             unit: (OPs  + $normUnit)
             tips:
           INT8 OPs:

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/1200_lds.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/1200_lds.yaml
@@ -55,48 +55,6 @@ Panel Config:
             max: MAX((SQ_INSTS_LDS / $denom))
             unit: (Instr  + $normUnit)
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS LOAD:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS STORE:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS ATOMIC:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS LOAD Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS STORE Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS ATOMIC Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
           Theoretical Bandwidth:
             avg: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
               / $denom))
@@ -157,18 +115,4 @@ Panel Config:
             min: MIN((SQ_LDS_MEM_VIOLATIONS / $denom))
             max: MAX((SQ_LDS_MEM_VIOLATIONS / $denom))
             unit: (Accesses + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS Command FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          LDS Data FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/1500_TA_and_TD.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/1500_TA_and_TD.yaml
@@ -43,27 +43,6 @@ Panel Config:
             max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
             unit: pct
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Address Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Command Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Data Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
           Total Instructions:
             avg: AVG((TA_TOTAL_WAVEFRONTS_sum / $denom))
             min: MIN((TA_TOTAL_WAVEFRONTS_sum / $denom))
@@ -80,12 +59,6 @@ Panel Config:
             avg: AVG((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Global/Generic Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Global/Generic Write Instructions:
@@ -110,12 +83,6 @@ Panel Config:
             avg: AVG((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Spill/Stack Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Spill/Stack Write Instructions:
@@ -203,11 +170,5 @@ Panel Config:
             avg: AVG((TD_ATOMIC_WAVEFRONT_sum / $denom))
             min: MIN((TD_ATOMIC_WAVEFRONT_sum / $denom))
             max: MAX((TD_ATOMIC_WAVEFRONT_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Write Ack Instructions:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/1600_L1_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/1600_L1_cache.yaml
@@ -192,30 +192,6 @@ Panel Config:
                         TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
-          Tag RAM 0 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 1 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 2 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 3 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           L1-L2 Read:
             avg: AVG((TCP_TCC_READ_REQ_sum / $denom))
             min: MIN((TCP_TCC_READ_REQ_sum / $denom))
@@ -236,24 +212,6 @@ Panel Config:
             max: MAX(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
             unit: (Req  + $normUnit)
-            tips:
-          L1 Access Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
-            tips:
-          L1-L2 Read Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
-            tips:
-          L1-L2 Write Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
             tips:
 
     - metric_table:
@@ -410,12 +368,6 @@ Panel Config:
             max: MAX((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             units: (Req + $normUnit)
             tips:
-          Misses under Translation Miss:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Req + $normUnit)
-            tips:
           Permission Misses:
             avg: AVG((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
@@ -433,45 +385,3 @@ Panel Config:
           units: Units
           tips: Tips
         metric:
-          Cache Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Cache Miss Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Serialization Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Thrashing Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Latency FIFO Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Resident Page Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          UTCL2 Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx941/1700_L2_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx941/1700_L2_cache.yaml
@@ -146,18 +146,6 @@ Panel Config:
               != 0) else None))
             unit: Cycles
             tips:
-          Read Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
 
     - metric_table:
         id: 1703
@@ -174,24 +162,6 @@ Panel Config:
             avg: AVG((TCC_REQ_sum * 128) / $denom)
             min: MIN((TCC_REQ_sum * 128) / $denom)
             max: MAX((TCC_REQ_sum * 128) / $denom)
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Bytes + $normUnit)
             tips:
           Req:
@@ -224,22 +194,10 @@ Panel Config:
             max: MAX((TCC_STREAMING_REQ_sum / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Bypasss Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           Probe Req:
             avg: AVG((TCC_PROBE_sum / $denom))
             min: MIN((TCC_PROBE_sum / $denom))
             max: MAX((TCC_PROBE_sum / $denom))
-            unit: (Req  + $normUnit)
-            tips:
-          Input Buffer Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Req  + $normUnit)
             tips:
           Cache Hit:
@@ -329,24 +287,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          Stalled on Latency FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Stalled on Write Data FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Input Buffer Stalled on L2:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
 
     - metric_table:
         id: 1705
@@ -363,54 +303,6 @@ Panel Config:
         style:
           type: simple_multi_bar
         metric:
-          Read - PCIe Stall:
-            type: PCIe Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - HBM Stall:
-            type: HBM Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - PCIe Stall:
-            type: PCIe Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - HBM Stall:
-            type: HBM Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
           Write - Credit Starvation:
             type: Credit Starvation
             transaction: Write
@@ -461,24 +353,6 @@ Panel Config:
             max: MAX((MAX((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Read Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Write and Atomic (32B):
             avg: AVG(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             min: MIN(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
@@ -509,51 +383,9 @@ Panel Config:
             max: MAX((MAX((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Write Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Atomic:
             avg: AVG((TCC_EA0_ATOMIC_sum / $denom))
             min: MIN((TCC_EA0_ATOMIC_sum / $denom))
             max: MAX((TCC_EA0_ATOMIC_sum / $denom))
             unit: (Req  + $normUnit)
-            tips:
-          Atomic - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Atomic Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/0200_system-speed-of-light.yaml
@@ -77,13 +77,6 @@ Panel Config:
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp))))
               / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP/s
-            peak: None
-            pop: None
-            tips:
           MFMA IOPs (Int8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
             unit: GIOP/s

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/0500_command-processor.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/0500_command-processor.yaml
@@ -76,27 +76,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC SYNC FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC CANE Stall Rate:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          CPC ADC Utilization:
-            avg: None
-            min: None
-            max: None
-            unit: pct
-            tips:
           CPC Utilization:
             avg: AVG((((100 * CPC_CPC_STAT_BUSY) / (CPC_CPC_STAT_BUSY + CPC_CPC_STAT_IDLE))
               if ((CPC_CPC_STAT_BUSY + CPC_CPC_STAT_IDLE) != 0) else None))

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/0600_shader-processor-input.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/0600_shader-processor-input.yaml
@@ -19,13 +19,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Schedule-Pipe Wave Occupancy:
-            avg: None
-            min: None
-            max: None
-            unit: Wave
-            tips:
           Accelerator Utilization:
             avg: AVG(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
             min: MIN(100 * $GRBM_GUI_ACTIVE_PER_XCD / $GRBM_COUNT_PER_XCD)
@@ -36,13 +29,6 @@ Panel Config:
             avg: AVG(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             min: MIN(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
             max: MAX(100 * SPI_CSN_BUSY / ($GRBM_GUI_ACTIVE_PER_XCD * $pipes_per_gpu * $se_per_gpu))
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe Wave Utilization:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Workgroup Manager Utilization:
@@ -120,13 +106,6 @@ Panel Config:
               0) else None)
             max: MAX((100 * SPI_RA_REQ_NO_ALLOC / ($GRBM_SPI_BUSY_PER_XCD * $se_per_gpu)) if ($GRBM_SPI_BUSY_PER_XCD !=
               0) else None)
-            unit: Pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Scheduler-Pipe FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
             unit: Pct
             tips:
           Scheduler-Pipe Stall Rate:

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/1000_compute-unit-instruction-mix.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/1000_compute-unit-instruction-mix.yaml
@@ -209,13 +209,6 @@ Panel Config:
             max: MAX((TA_BUFFER_WAVEFRONTS_sum / $denom))
             unit: (instr + $normUnit)
             tips:
-         # TODO: Fix baseline comparision logic to handle non existent metrics, then remove this
-          Spill/Stack Coalesceable Instr:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
           Spill/Stack Read:
             avg: AVG((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
@@ -280,12 +273,5 @@ Panel Config:
             avg: AVG((SQ_INSTS_VALU_MFMA_F64 / $denom))
             min: MIN((SQ_INSTS_VALU_MFMA_F64 / $denom))
             max: MAX((SQ_INSTS_VALU_MFMA_F64 / $denom))
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA-F6F4:
-            avg: None
-            min: None
-            max: None
             unit: (instr + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/1100_compute-unit-compute-pipeline.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/1100_compute-unit-compute-pipeline.yaml
@@ -76,13 +76,6 @@ Panel Config:
             pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp))))
               / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          MFMA FLOPs (F6F4):
-            value: None
-            unit: GFLOP
-            peak: None
-            pop: None
-            tips:
           MFMA IOPs (INT8):
             value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
             unit: GIOP
@@ -130,13 +123,6 @@ Panel Config:
             avg: AVG((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             min: MIN((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
             max: MAX((((100 * SQ_ACTIVE_INST_VALU) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
-            unit: pct
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          VALU Co-Issue Efficiency:
-            avg: None
-            min: None
-            max: None
             unit: pct
             tips:
           VMEM Utilization:
@@ -277,13 +263,6 @@ Panel Config:
               + (SQ_INSTS_VALU_FMA_F64 * 2))) + (512 * SQ_INSTS_VALU_MFMA_MOPS_F64)) / $denom))
             max: MAX((((64 * (((SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64) + SQ_INSTS_VALU_TRANS_F64)
               + (SQ_INSTS_VALU_FMA_F64 * 2))) + (512 * SQ_INSTS_VALU_MFMA_MOPS_F64)) / $denom))
-            unit: (OPs  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          F6F4 OPs:
-            avg: None
-            min: None
-            max: None
             unit: (OPs  + $normUnit)
             tips:
           INT8 OPs:

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/1200_lds.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/1200_lds.yaml
@@ -56,48 +56,6 @@ Panel Config:
             max: MAX((SQ_INSTS_LDS / $denom))
             unit: (Instr  + $normUnit)
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then
-          LDS LOAD:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then
-          LDS STORE:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then
-          LDS ATOMIC:
-            avg: None
-            min: None
-            max: None
-            unit: (instr + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then
-          LDS LOAD Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then
-          LDS STORE Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then
-          LDS ATOMIC Bandwidth:
-            avg: None
-            min: None
-            max: None
-            units: Gbps
-            tips:
           Theoretical Bandwidth:
             avg: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
               / $denom))
@@ -158,18 +116,4 @@ Panel Config:
             min: MIN((SQ_LDS_MEM_VIOLATIONS / $denom))
             max: MAX((SQ_LDS_MEM_VIOLATIONS / $denom))
             unit: (Accesses + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then
-          LDS Command FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then
-          LDS Data FIFO Full Rate:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/1500_TA_and_TD.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/1500_TA_and_TD.yaml
@@ -43,27 +43,6 @@ Panel Config:
             max: MAX(((100 * TA_ADDR_STALLED_BY_TD_CYCLES_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
             unit: pct
             tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Address Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Command Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
-          # TODO: Fix baseline comparision logic to handle non existent metrics, then 
-          Sequencer → TA Data Stall:
-            avg: None
-            min: None
-            max: None
-            unit: (Cycles + $normUnit)
-            tips:
           Total Instructions:
             avg: AVG((TA_TOTAL_WAVEFRONTS_sum / $denom))
             min: MIN((TA_TOTAL_WAVEFRONTS_sum / $denom))
@@ -80,12 +59,6 @@ Panel Config:
             avg: AVG((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_FLAT_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Global/Generic Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Global/Generic Write Instructions:
@@ -110,12 +83,6 @@ Panel Config:
             avg: AVG((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             min: MIN((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
             max: MAX((TA_BUFFER_READ_WAVEFRONTS_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Spill/Stack Read Instructions for LDS:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:
           Spill/Stack Write Instructions:
@@ -203,11 +170,5 @@ Panel Config:
             avg: AVG((TD_ATOMIC_WAVEFRONT_sum / $denom))
             min: MIN((TD_ATOMIC_WAVEFRONT_sum / $denom))
             max: MAX((TD_ATOMIC_WAVEFRONT_sum / $denom))
-            unit: (Instructions  + $normUnit)
-            tips:
-          Write Ack Instructions:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Instructions  + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/1600_L1_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/1600_L1_cache.yaml
@@ -194,30 +194,6 @@ Panel Config:
                         TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)) / $denom))
             unit: (Bytes + $normUnit)
             tips:
-          Tag RAM 0 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 1 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 2 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Tag RAM 3 Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           L1-L2 Read:
             avg: AVG((TCP_TCC_READ_REQ_sum / $denom))
             min: MIN((TCP_TCC_READ_REQ_sum / $denom))
@@ -238,24 +214,6 @@ Panel Config:
             max: MAX(((TCP_TCC_ATOMIC_WITH_RET_REQ_sum + TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
               / $denom))
             unit: (Req  + $normUnit)
-            tips:
-          L1 Access Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
-            tips:
-          L1-L2 Read Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
-            tips:
-          L1-L2 Write Latency:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: Cycles
             tips:
 
     - metric_table:
@@ -412,12 +370,6 @@ Panel Config:
             max: MAX((TCP_UTCL1_TRANSLATION_MISS_sum / $denom))
             units: (Req + $normUnit)
             tips:
-          Misses under Translation Miss:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Req + $normUnit)
-            tips:
           Permission Misses:
             avg: AVG((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
             min: MIN((TCP_UTCL1_PERMISSION_MISS_sum / $denom))
@@ -435,45 +387,3 @@ Panel Config:
           units: Units
           tips: Tips
         metric:
-          Cache Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Cache Miss Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Serialization Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Thrashing Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Latency FIFO Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          Resident Page Full Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:
-          UTCL2 Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            units: (Cycles + $normUnit)
-            tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx942/1700_L2_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx942/1700_L2_cache.yaml
@@ -150,18 +150,6 @@ Panel Config:
               != 0) else None))
             unit: Cycles
             tips:
-          Read Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write Stall:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
 
     - metric_table:
         id: 1703
@@ -178,24 +166,6 @@ Panel Config:
             avg: AVG((TCC_REQ_sum * 128) / $denom)
             min: MIN((TCC_REQ_sum * 128) / $denom)
             max: MAX((TCC_REQ_sum * 128) / $denom)
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Bytes + $normUnit)
             tips:
           Req:
@@ -228,22 +198,10 @@ Panel Config:
             max: MAX((TCC_STREAMING_REQ_sum / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Bypasss Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
           Probe Req:
             avg: AVG((TCC_PROBE_sum / $denom))
             min: MIN((TCC_PROBE_sum / $denom))
             max: MAX((TCC_PROBE_sum / $denom))
-            unit: (Req  + $normUnit)
-            tips:
-          Input Buffer Req:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
             unit: (Req  + $normUnit)
             tips:
           Cache Hit:
@@ -333,24 +291,6 @@ Panel Config:
           unit: Unit
           tips: Tips
         metric:
-          Stalled on Latency FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Stalled on Write Data FIFO:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
-          Input Buffer Stalled on L2:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Cycles + $normUnit)
-            tips:
 
     - metric_table:
         id: 1705
@@ -367,54 +307,6 @@ Panel Config:
         style:
           type: simple_multi_bar
         metric:
-          Read - PCIe Stall:
-            type: PCIe Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Read - HBM Stall:
-            type: HBM Stall
-            transaction: Read
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - PCIe Stall:
-            type: PCIe Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - Infinity Fabric™ Stall:
-            type: Infinity Fabric™ Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
-          Write - HBM Stall:
-            type: HBM Stall
-            transaction: Write
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: pct
-            tips:
           Write - Credit Starvation:
             type: Credit Starvation
             transaction: Write
@@ -471,24 +363,6 @@ Panel Config:
             max: MAX((MAX((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Read Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Write and Atomic (32B):
             avg: AVG(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             min: MIN(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
@@ -519,51 +393,9 @@ Panel Config:
             max: MAX((MAX((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Write Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Write Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
           Atomic:
             avg: AVG((TCC_EA0_ATOMIC_sum / $denom))
             min: MIN((TCC_EA0_ATOMIC_sum / $denom))
             max: MAX((TCC_EA0_ATOMIC_sum / $denom))
             unit: (Req  + $normUnit)
-            tips:
-          Atomic - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Req  + $normUnit)
-            tips:
-          Atomic Bandwidth - PCIe:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - Infinity Fabric™:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
-            tips:
-          Atomic Bandwidth - HBM:
-            avg: None # Missing perfmon
-            min: None # Missing perfmon
-            max: None # Missing perfmon
-            unit: (Bytes + $normUnit)
             tips:

--- a/src/rocprof_compute_soc/analysis_configs/gfx950/1700_L2_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx950/1700_L2_cache.yaml
@@ -473,24 +473,6 @@ Panel Config:
             max: MAX((MAX((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), 0) / $denom))
             unit: (Req  + $normUnit)
             tips:
-          Read Bandwidth - PCIe:
-            avg: None # AVG(TCC_EA0_RDREQ_IO_32B_sum / $denom)
-            min: None # MIN(TCC_EA0_RDREQ_IO_32B_sum / $denom)
-            max: None # MAX(TCC_EA0_RDREQ_IO_32B_sum / $denom)
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - Infinity Fabric™:
-            avg: None # AVG(TCC_EA0_RDREQ_GMI_32B_sum / $denom)
-            min: None # MIN(TCC_EA0_RDREQ_GMI_32B_sum / $denom)
-            max: None # MAX(TCC_EA0_RDREQ_GMI_32B_sum / $denom)
-            unit: (Bytes + $normUnit)
-            tips:
-          Read Bandwidth - HBM:
-            avg: None # AVG(TCC_EA0_RDREQ_DRAM_32B_sum / $denom)
-            min: None # MIN(TCC_EA0_RDREQ_DRAM_32B_sum / $denom)
-            max: None # MAX(TCC_EA0_RDREQ_DRAM_32B_sum / $denom)
-            unit: (Bytes + $normUnit)
-            tips:
           Write and Atomic (32B):
             avg: AVG(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))
             min: MIN(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom))

--- a/src/utils/file_io.py
+++ b/src/utils/file_io.py
@@ -75,6 +75,12 @@ def load_panel_configs(dir):
             if f.endswith(".yaml"):
                 with open(str(Path(root).joinpath(f))) as file:
                     config = yaml.safe_load(file)
+                    # metric key can be None due to some metric tables not having any metrics
+                    # metric key should be empty dict instead of None
+                    for data_source in config["Panel Config"]["data source"]:
+                        metric_table = data_source.get("metric_table")
+                        if metric_table and metric_table["metric"] is None:
+                            metric_table["metric"] = {}
                     d[config["Panel Config"]["id"]] = config["Panel Config"]
 
     # TODO: sort metrics as the header order in case they are not defined in the same order


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
* Do not force unsupported metrics to be specified in older gpu
  architectures as None

* Remove metrics which are explicitly set to None

* Update CHANGELOG

* Fix analysis configuration to fix baseline comparisons across all gpu
  architectures
    * Add missing 1812 section for gfx908
    * Add missing 1812 section for gfx90a

* Baseline comparison should only show common metrics

LDS Stats section for gfx950 (MI 350 series)

<img width="549" height="475" alt="{EFED311E-FA90-45D4-8890-8BE26D951EE4}" src="https://github.com/user-attachments/assets/e67efa9c-4761-4c6f-a1d8-d7e1e8bc5d4a" />


LDS Stats section for gfx942 (MI 300 series)

<img width="521" height="294" alt="{66929835-8BBE-47AD-AD8D-C6C708AEA0EE}" src="https://github.com/user-attachments/assets/8ab7e817-e5de-4c68-bedc-44c3baf349fd" />


LDS Stats section in baseline comparison mode between gfx950 (first workload) and gfx942 (second workload).
Note that Metric IDs correspond to first workload.

<img width="776" height="293" alt="{D076CBD4-2410-4072-8646-5689BBC272C1}" src="https://github.com/user-attachments/assets/81c40fd5-eb9e-4114-bdbe-027c4ee4cd9f" />

## Have you added or updated tests to validate functionality?

- [x] Yes
- [ ] No - does not apply to this PR
Validated baseline comparison working across all gpu architectures

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [x] Yes
- [ ] No - does not apply to this PR
