### PR TITLE
fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,6 @@ add_test(
         --junitxml=tests/test_profile_dispatch.xml ${COV_OPTION}
         ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-set_property(TEST test_profile_ipblocks PROPERTY COST 5)
 
 add_test(
     NAME test_profile_mem
@@ -257,7 +256,6 @@ add_test(
 
 set_tests_properties(
     test_profile_kernel_execution
-    test_profile_ipblocks
     test_profile_dispatch
     test_profile_mem
     test_profile_join


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
Remove unused ipblock test from cmake.
This fixes cmake build which got broken due to https://github.com/ROCm/rocprofiler-compute/pull/820

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [ ] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [ ] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [ ] No - does not apply to this PR
