### PR TITLE
Standalone GUI bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * Fixed not collecting TCC channel counters in rocprof v3
 * Fixed peak FLOPS of F8 I8 F16 and BF16 on MI300
 * Fixed not detecting memory clock issue when using amd-smi
+* Fix standalone GUI crashing
 
 ### Known issues
 

--- a/src/rocprof_compute_analyze/analysis_webui.py
+++ b/src/rocprof_compute_analyze/analysis_webui.py
@@ -36,7 +36,7 @@ from config import HIDDEN_COLUMNS, PROJECT_NAME
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser
 from utils.gui import build_bar_chart, build_table_chart
-from utils.logger import console_debug, console_error, demarcate
+from utils.logger import console_debug, console_error, console_warning, demarcate
 
 
 class webui_analysis(OmniAnalyze_Base):
@@ -53,7 +53,9 @@ class webui_analysis(OmniAnalyze_Base):
         # define different types of bar charts
         self.__barchart_elements = {
             "instr_mix": [1001, 1002],
-            "multi_bar": [1604, 1704],
+            # 1604: L1D - L2 Transactions
+            # 1705: L2 - Fabric Interface Stalls
+            "multi_bar": [1604, 1705],
             "sol": [1101, 1201, 1301, 1401, 1601, 1701],
             # "l2_cache_per_chan": [1802, 1803]
         }
@@ -371,7 +373,11 @@ def determine_chart_type(
 
     # Determine chart type:
     # a) Barchart
-    if table_config["id"] in [x for i in barchart_elements.values() for x in i]:
+    if original_df.empty:
+        console_warning(
+            f"The dataframe with id={table_config['id']} is empty! Not displaying it."
+        )
+    elif table_config["id"] in [x for i in barchart_elements.values() for x in i]:
         d_figs = build_bar_chart(display_df, table_config, barchart_elements, norm_filt)
         # Smaller formatting if barchart yeilds several graphs
         if (

--- a/src/rocprof_compute_soc/analysis_configs/gfx950/1700_L2_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx950/1700_L2_cache.yaml
@@ -40,6 +40,10 @@ Panel Config:
               * 32)) / (End_Timestamp - Start_Timestamp)))
             unit: GB/s
             tips:
+          HBM Bandwidth:
+            value: $hbmBandwidth
+            unit: GB/s
+            tips:
 
     - metric_table:
         id: 1702

--- a/src/utils/gui.py
+++ b/src/utils/gui.py
@@ -52,7 +52,7 @@ def multi_bar_chart(table_id, display_df):
         nested_bar = {"NC": {}, "UC": {}, "RW": {}, "CC": {}}
         for index, row in display_df.iterrows():
             nested_bar[row["Coherency"]][row["Xfer"]] = row["Avg"]
-    if table_id == 1704:
+    if table_id == 1705:  # L2 - Fabric Interface Stalls
         nested_bar = {"Read": {}, "Write": {}}
         for index, row in display_df.iterrows():
             nested_bar[row["Transaction"]][row["Type"]] = row["Avg"]
@@ -198,7 +198,7 @@ def build_bar_chart(display_df, table_config, barchart_elements, norm_filt):
     # Speed-of-light bar chart
     elif table_config["id"] in barchart_elements["sol"]:
         display_df["Avg"] = [
-            x.astype(float) if x != "" else float(0) for x in display_df["Avg"]
+            float(x) if x != "" else float(0) for x in display_df["Avg"]
         ]
         if table_config["id"] == 1701:
             # special layout for L2 Cache SOL


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
Coming from https://github.com/ROCm/rocprofiler-compute/pull/787 reported by @fxmarty-amd
Standalone GUI bugfix
* Fix barchart elements table ids

* Add HBM bandwidth section to L2 cache report for gfx950

* bugfix for standlone GUI


## Have you added or updated tests to validate functionality?

- [x] Yes
- [ ] No - does not apply to this PR

Section 17.1 and 17.5 barcharts work fine now

<img width="501" height="363" alt="{9FB72C4F-C12B-4132-8447-87A43AFDB7DE}" src="https://github.com/user-attachments/assets/8fe7cf7d-bd4e-4a7d-a500-68baa0c36989" />

Note that below values are 0 since the workload profiled does not have L2 <-> HBM transactions
<img width="505" height="254" alt="{3CCD4D20-187A-43A2-B97A-D84506340565}" src="https://github.com/user-attachments/assets/96cffda0-8da6-4e0d-b145-802d4735930a" />


## Added / Updated documentation?

- [ ] Yes
- [ ] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [x] Yes
- [ ] No - does not apply to this PR
