### PR TITLE
Fix L2 read/write/atomic bandwidths on MI350

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * Fixed not collecting TCC channel counters in rocprof v3
 * Fixed peak FLOPS of F8 I8 F16 and BF16 on MI300
 * Fixed not detecting memory clock issue when using amd-smi
-* Fix standalone GUI crashing
+* Fixed standalone GUI crashing
+* Fixed L2 read/write/atomic bandwidths on MI350
 
 ### Known issues
 

--- a/src/rocprof_compute_soc/analysis_configs/gfx950/1700_L2_cache.yaml
+++ b/src/rocprof_compute_soc/analysis_configs/gfx950/1700_L2_cache.yaml
@@ -183,21 +183,21 @@ Panel Config:
             unit: (Bytes + $normUnit)
             tips:
           Read Bandwidth:
-            avg: AVG(TCC_READ_SECTORS_sum / $denom)
-            min: MIN(TCC_READ_SECTORS_sum / $denom)
-            max: MAX(TCC_READ_SECTORS_sum / $denom)
+            avg: AVG(TCC_READ_SECTORS_sum * 32 / $denom)
+            min: MIN(TCC_READ_SECTORS_sum * 32 / $denom)
+            max: MAX(TCC_READ_SECTORS_sum * 32 / $denom)
             unit: (Bytes + $normUnit)
             tips:
           Write Bandwidth:
-            avg: AVG(TCC_WRITE_SECTORS_sum / $denom)
-            min: MIN(TCC_WRITE_SECTORS_sum / $denom)
-            max: MAX(TCC_WRITE_SECTORS_sum / $denom)
+            avg: AVG(TCC_WRITE_SECTORS_sum * 32 / $denom)
+            min: MIN(TCC_WRITE_SECTORS_sum * 32 / $denom)
+            max: MAX(TCC_WRITE_SECTORS_sum * 32 / $denom)
             unit: (Bytes + $normUnit)
             tips:
           Atomic Bandwidth:
-            avg: AVG(TCC_ATOMIC_SECTORS_sum / $denom)
-            min: MIN(TCC_ATOMIC_SECTORS_sum / $denom)
-            max: MAX(TCC_ATOMIC_SECTORS_sum / $denom)
+            avg: AVG(TCC_ATOMIC_SECTORS_sum * 32 / $denom)
+            min: MIN(TCC_ATOMIC_SECTORS_sum * 32 / $denom)
+            max: MAX(TCC_ATOMIC_SECTORS_sum * 32 / $denom)
             unit: (Bytes + $normUnit)
             tips:
           Req:


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [x] Closes SWDEV-545884

## What type of PR is this? (check all that apply)

- [X] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
With the reg spec, all TCC_***_SECTORS should be scaled by 32 B.
## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
