### PR TITLE
Fix rocprofv3 supported counters not being detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,13 +255,9 @@ add_test(
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 set_tests_properties(
-    test_profile_kernel_execution
-    test_profile_dispatch
-    test_profile_mem
-    test_profile_join
-    test_profile_sort
-    test_profile_misc
-    PROPERTIES LABELS "profile" RESOURCE_GROUPS gpus:1)
+    test_profile_kernel_execution test_profile_dispatch test_profile_mem test_profile_join
+    test_profile_sort test_profile_misc PROPERTIES LABELS "profile" RESOURCE_GROUPS
+                                                   gpus:1)
 
 # ---------------------------
 # analysis command tests

--- a/src/rocprof_compute_soc/soc_base.py
+++ b/src/rocprof_compute_soc/soc_base.py
@@ -426,6 +426,17 @@ class OmniSoC_Base:
 
     def get_rocprof_supported_counters(self):
         rocprof_cmd = detect_rocprof(self.get_args())
+
+        if rocprof_cmd != "rocprofiler-sdk":
+            console_warning(
+                "rocprof v1 / v2 / v3 interfaces will be removed in favor of "
+                "rocprofiler-sdk interface in a future release. To use rocprofiler-sdk "
+                "interface, please set the environment variable ROCPROF to 'rocprofiler-sdk' "
+                "and optionally provide the path to librocprofiler-sdk.so library via the "
+                "--rocprofiler-sdk-library-path option."
+            )
+
+
         rocprof_counters = set()
 
         if str(rocprof_cmd).endswith("rocprof"):
@@ -475,7 +486,7 @@ class OmniSoC_Base:
                     f"Failed to list rocprof supported counters using command: {command}"
                 )
             for line in output.splitlines():
-                if "Name:" in line:
+                if "counter_name" in line:
                     counters, _ = self.parse_counters_text(line.split(":")[1].strip())
                     rocprof_counters.update(counters)
             # Custom counter support for mi100 for rocprofv3

--- a/src/rocprof_compute_soc/soc_base.py
+++ b/src/rocprof_compute_soc/soc_base.py
@@ -436,7 +436,6 @@ class OmniSoC_Base:
                 "--rocprofiler-sdk-library-path option."
             )
 
-
         rocprof_counters = set()
 
         if str(rocprof_cmd).endswith("rocprof"):

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -245,14 +245,6 @@ def detect_rocprof(args):
         )
         return rocprof_cmd
 
-    console_warning(
-        "rocprof v1 / v2 / v3 interfaces will be deprecated in favor of "
-        "rocprofiler-sdk interface in a future release. To use rocprofiler-sdk "
-        "interface, please set the environment variable ROCPROF to 'rocprofiler-sdk' "
-        "and optionally provide the path to librocprofiler-sdk.so library via the "
-        "--rocprofiler-sdk-library-path option."
-    )
-
     # detect rocprof
     if not "ROCPROF" in os.environ.keys():
         # default rocprof


### PR DESCRIPTION
* Fix rocprof interface deprecation warning appearing twice

# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
[Fix rocprofv3 supported counters not being detected](https://github.com/ROCm/rocprofiler-compute/pull/832/commits/4026a9d7bf14eb1e48522f6df1ff668c44e35090)
* Fix rocprof interface deprecation warning appearing twice

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR, Manually tested

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
