### PR TITLE
[PC Sampling]: quick fix for how to invoke rocprof

### DIFF
--- a/src/rocprof_compute_profile/profiler_base.py
+++ b/src/rocprof_compute_profile/profiler_base.py
@@ -27,6 +27,7 @@ import glob
 import logging
 import os
 import re
+import shlex
 import shutil
 import time
 from abc import ABC, abstractmethod
@@ -462,7 +463,9 @@ class RocProfCompute_Base:
                 method=self.get_args().pc_sampling_method,
                 interval=self.get_args().pc_sampling_interval,
                 workload_dir=self.get_args().path,
-                appcmd=self.get_args().remaining,
+                appcmd=shlex.split(
+                    self.get_args().remaining
+                ),  # FIXME: the right solution is applying it when argparsing once!
                 rocprofiler_sdk_library_path=self.get_args().rocprofiler_sdk_library_path,
             )
             end_run_prof = time.time()

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1018,8 +1018,9 @@ def pc_sampling_prof(
             "-o",
             "ps_file",  # todo: sync up with the name from source in 2100_.yaml
             "--",
-            appcmd,
         ]
+        options.extend(appcmd)
+
         success, output = capture_subprocess_output(
             [rocprof_cmd] + options, new_env=os.environ.copy(), profileMode=True
         )


### PR DESCRIPTION
# rocprofiler-compute Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [x] Closes # SWDEV-541054

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
The technical evaluation is: the profiling target app cmd string(in args.remaining) should be converted to list before calling rocprof. We have some good practice for other places in the code, https://github.com/ROCm/rocprofiler-compute/blob/c7b5a0f43aba4ec72b8bebcdacb579d9a52cf1bc/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py#L43. We apply similar solution to this case as a quick fix. 
Discussed with @vedithal-amd, we could have better unified solution: apply a transformation function in argparser once(Commented in the code). Because of the time limitation, will do it later after next week. 
## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
